### PR TITLE
feat(fund-reports): wire Generate Report + basic report renderers for Fund Balance/Activity/Statement/Comparison

### DIFF
--- a/check-printing.html
+++ b/check-printing.html
@@ -161,7 +161,9 @@
 
         <!-- New Check Tab -->
         <div id="new-check" class="tab-panel">
-            <div class="check-form">
+            <form id="check-form">
+                <div id="check-status" class="visually-hidden"></div>
+                <div class="check-form">
                 <div class="form-section">
                     <h3>Check Information</h3>
                     <div class="form-row">
@@ -246,11 +248,12 @@
                 </div>
 
                 <div class="form-actions">
-                    <button id="check-save" class="action-button">Save as Draft</button>
-                    <button id="check-print" class="action-button primary">Print Now</button>
-                    <button id="check-cancel" class="action-button secondary">Cancel</button>
+                    <button id="check-save" type="button" class="action-button">Save as Draft</button>
+                    <button id="check-print" type="button" class="action-button primary">Print Now</button>
+                    <button id="check-cancel" type="button" class="action-button secondary">Cancel</button>
                 </div>
-            </div>
+                </div><!-- /.check-form -->
+            </form>
         </div>
 
         <!-- Print Queue Tab -->

--- a/index.html
+++ b/index.html
@@ -373,16 +373,192 @@
     <div id="log-output-container"><div id="log-output"></div></div>
 
     <!-- Modals -->
-    <div id="account-modal" class="modal-overlay"><div class="modal-dialog"><div class="modal-header"><h3 class="modal-title" id="account-modal-title">Account</h3><button class="modal-close-btn" data-modal-id="account-modal">&times;</button></div><div class="modal-body"><input type="hidden" id="edit-account-id-input"><div class="form-group"><label class="form-label" for="account-code-input">Account Code</label><input type="text" id="account-code-input" class="form-input"></div><div class="form-group"><label class="form-label" for="account-name-input">Account Name</label><input type="text" id="account-name-input" class="form-input"></div><div class="form-row"><div class="form-column"><div class="form-group"><label class="form-label" for="account-type-select">Account Type</label><select id="account-type-select" class="form-input"><option value="Asset">Asset</option><option value="Liability">Liability</option><option value="Equity">Equity</option><option value="Revenue">Revenue</option><option value="Expense">Expense</option></select></div></div><div class="form-column"><div class="form-group"><label class="form-label" for="account-status-select">Status</label><select id="account-status-select" class="form-input"><option value="Active">Active</option><option value="Inactive">Inactive</option></select></div></div></div><div class="form-group"><label class="form-label" for="account-description-textarea">Description</label><textarea id="account-description-textarea" class="form-input" rows="3"></textarea></div></div><div class="modal-footer"><button class="btn-secondary modal-close-btn" data-modal-id="account-modal">Cancel</button><button class="action-button" id="save-account-btn">Save Account</button></div></div></div>
-    <div id="fund-modal" class="modal-overlay"><div class="modal-dialog"><div class="modal-header"><h3 class="modal-title" id="fund-modal-title">Fund</h3><button class="modal-close-btn" data-modal-id="fund-modal">&times;</button></div><div class="modal-body"><input type="hidden" id="edit-fund-id-input"><div class="form-group"><label class="form-label" for="fund-code-input">Fund Code</label><input type="text" id="fund-code-input" class="form-input"></div><div class="form-group"><label class="form-label" for="fund-name-input">Fund Name</label><input type="text" id="fund-name-input" class="form-input"></div><div class="form-row"><div class="form-column"><div class="form-group"><label class="form-label" for="fund-type-select">Fund Type</label><select id="fund-type-select" class="form-input"><option value="Unrestricted">Unrestricted</option><option value="Temporarily Restricted">Temporarily Restricted</option><option value="Permanently Restricted">Permanently Restricted</option></select></div></div><div class="form-column"><div class="form-group"><label class="form-label" for="fund-status-select">Status</label><select id="fund-status-select" class="form-input"><option value="Active">Active</option><option value="Inactive">Inactive</option></select></div></div></div><div class="form-group"><label class="form-label" for="fund-description-textarea">Description</label><textarea id="fund-description-textarea" class="form-input" rows="3"></textarea></div></div><div class="modal-footer"><button class="btn-secondary modal-close-btn" data-modal-id="fund-modal">Cancel</button><button class="btn-danger" id="delete-fund-btn" style="display:none;">Delete Fund</button><button class="action-button" id="save-fund-btn">Save Fund</button></div></div></div>
+    <div id="account-modal" class="modal-overlay">
+        <div class="modal-dialog">
+            <div class="modal-header">
+                <h3 class="modal-title" id="account-modal-title">Account</h3>
+                <button class="modal-close-btn" id="account-modal-close" data-modal-id="account-modal">&times;</button>
+            </div>
+            <!-- ---------- Account Form (captured by app-modals.js) ---------- -->
+            <form id="account-modal-form">
+                <div class="modal-body">
+                    <input type="hidden" id="edit-account-id-input">
+
+                    <div class="form-group">
+                        <label class="form-label" for="account-code-input">Account Code *</label>
+                        <input type="text"
+                               id="account-code-input"
+                               name="account-code"
+                               class="form-input"
+                               required>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label" for="account-name-input">Account Name *</label>
+                        <input type="text"
+                               id="account-name-input"
+                               name="account-name"
+                               class="form-input"
+                               required>
+                    </div>
+
+                    <!-- Entity selector injected ahead of type / status -->
+                    <div class="form-group">
+                        <label class="form-label" for="account-entity-id">Entity</label>
+                        <select id="account-entity-id"
+                                name="account-entity-id"
+                                class="form-input">
+                            <option value="">Select Entity…</option>
+                        </select>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-column">
+                            <div class="form-group">
+                                <label class="form-label" for="account-type-select">Account Type *</label>
+                                <select id="account-type-select"
+                                        name="account-type"
+                                        class="form-input"
+                                        required>
+                                    <option value="Asset">Asset</option>
+                                    <option value="Liability">Liability</option>
+                                    <option value="Equity">Equity</option>
+                                    <option value="Revenue">Revenue</option>
+                                    <option value="Expense">Expense</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-column">
+                            <div class="form-group">
+                                <label class="form-label" for="account-status-select">Status</label>
+                                <select id="account-status-select"
+                                        name="account-status"
+                                        class="form-input">
+                                    <option value="Active">Active</option>
+                                    <option value="Inactive">Inactive</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label" for="account-description-textarea">Description</label>
+                        <textarea id="account-description-textarea"
+                                  name="account-description"
+                                  class="form-input"
+                                  rows="3"></textarea>
+                    </div>
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button"
+                            class="btn-secondary modal-close-btn"
+                            id="account-modal-cancel"
+                            data-modal-id="account-modal">Cancel</button>
+                    <button type="submit"
+                            class="action-button"
+                            id="save-account-btn">Save Account</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div id="fund-modal" class="modal-overlay">
+        <div class="modal-dialog">
+            <div class="modal-header">
+                <h3 class="modal-title" id="fund-modal-title">Fund</h3>
+                <button class="modal-close-btn" id="fund-modal-close" data-modal-id="fund-modal">&times;</button>
+            </div>
+            <!-- ---------- Fund Form ---------- -->
+            <form id="fund-modal-form">
+                <div class="modal-body">
+                    <input type="hidden" id="edit-fund-id-input">
+
+                    <div class="form-group">
+                        <label class="form-label" for="fund-code-input">Fund Code *</label>
+                        <input type="text"
+                               id="fund-code-input"
+                               name="fund-code"
+                               class="form-input"
+                               required>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label" for="fund-name-input">Fund Name *</label>
+                        <input type="text"
+                               id="fund-name-input"
+                               name="fund-name"
+                               class="form-input"
+                               required>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label" for="fund-entity-id">Entity</label>
+                        <select id="fund-entity-id"
+                                name="fund-entity-id"
+                                class="form-input">
+                            <option value="">Select Entity…</option>
+                        </select>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-column">
+                            <div class="form-group">
+                                <label class="form-label" for="fund-type-select">Fund Type *</label>
+                                <select id="fund-type-select"
+                                        name="fund-type"
+                                        class="form-input"
+                                        required>
+                                    <option value="Unrestricted">Unrestricted</option>
+                                    <option value="Temporarily Restricted">Temporarily Restricted</option>
+                                    <option value="Permanently Restricted">Permanently Restricted</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-column">
+                            <div class="form-group">
+                                <label class="form-label" for="fund-status-select">Status</label>
+                                <select id="fund-status-select"
+                                        name="fund-status"
+                                        class="form-input">
+                                    <option value="Active">Active</option>
+                                    <option value="Inactive">Inactive</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label" for="fund-description-textarea">Description</label>
+                        <textarea id="fund-description-textarea"
+                                  name="fund-description"
+                                  class="form-input"
+                                  rows="3"></textarea>
+                    </div>
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button"
+                            class="btn-secondary modal-close-btn"
+                            id="fund-modal-cancel"
+                            data-modal-id="fund-modal">Cancel</button>
+                    <button class="btn-danger" id="delete-fund-btn" style="display:none;">Delete Fund</button>
+                    <button type="submit"
+                            class="action-button"
+                            id="save-fund-btn">Save Fund</button>
+                </div>
+            </form>
+        </div>
+    </div>
     <div id="journal-entry-modal" class="modal-overlay"><div class="modal-dialog modal-dialog-lg"><div class="modal-header"><h3 class="modal-title" id="journal-entry-modal-title">New Journal Entry</h3><button class="modal-close-btn" data-modal-id="journal-entry-modal">&times;</button></div><div class="modal-body"><input type="hidden" id="edit-je-id-input"><div class="form-row"><div class="form-column"><div class="form-group"><label class="form-label" for="journal-entry-date">Date</label><input type="date" id="journal-entry-date" class="form-input"></div></div><div class="form-column"><div class="form-group"><label class="form-label" for="journal-entry-reference">Reference</label><input type="text" id="journal-entry-reference" class="form-input" readonly></div></div></div><div class="form-group"><label class="form-label" for="journal-entry-description">Description</label><input type="text" id="journal-entry-description" class="form-input" placeholder="Enter transaction description..."></div><div class="form-group"><label class="form-label"><input type="checkbox" id="journal-entry-is-inter-entity" class="form-input"> Is Inter-Entity Transfer?</label></div><div id="inter-entity-fields-container" class="inter-entity-fields"><div class="form-row"><div class="form-column"><div class="form-group"><label class="form-label" for="journal-entry-target-entity">Target Entity</label><select id="journal-entry-target-entity" class="form-input"><option value="">Select Target Entity...</option></select></div></div><div class="form-column"><div class="form-group"><label class="form-label" for="journal-entry-matching-tx-id">Matching Transaction ID (Optional)</label><input type="text" id="journal-entry-matching-tx-id" class="form-input" placeholder="Auto-generated if blank"></div></div></div></div><h4 style="margin: 20px 0 10px 0;">Journal Entry Lines</h4><table class="data-table" id="journal-lines-table"><thead><tr><th>Account</th><th>Fund</th><th>Debit</th><th>Credit</th><th>Description</th><th>Action</th></tr></thead><tbody id="journal-lines"></tbody></table><button id="add-journal-line" class="btn-secondary" style="margin-top: 10px;">Add Line</button><div class="totals-summary"><div class="form-group"><label class="form-label">Total Debits</label><input type="text" id="journal-total-debits" class="form-input" value="$0.00" readonly></div><div class="form-group"><label class="form-label">Total Credits</label><input type="text" id="journal-total-credits" class="form-input" value="$0.00" readonly></div><div class="form-group"><label class="form-label">Difference</label><input type="text" id="journal-difference" class="form-input" value="$0.00" readonly></div></div></div><div class="modal-footer"><button class="btn-secondary modal-close-btn" data-modal-id="journal-entry-modal">Cancel</button><button class="action-button" id="btn-save-journal-draft">Save as Draft</button><button class="action-button" id="btn-save-journal-post">Save & Post</button></div></div></div>
     <!-- Enhanced Entity Modal -->
     <div id="entity-modal" class="modal-overlay">
         <div class="modal-dialog modal-dialog-lg">
             <div class="modal-header">
                 <h3 class="modal-title" id="entity-modal-title-text">Entity</h3>
-                <button class="modal-close-btn" data-modal-id="entity-modal">&times;</button>
+                <button class="modal-close-btn" id="entity-modal-close" data-modal-id="entity-modal">&times;</button>
             </div>
+            <!-- ---------- Entity Form ---------- -->
+            <form id="entity-modal-form">
             <div class="modal-body">
                 <!-- Hidden field for entity ID when editing -->
                 <input type="hidden" id="entity-id-edit">
@@ -394,13 +570,21 @@
                         <div class="form-column">
                             <div class="form-group">
                                 <label class="form-label" for="entity-name-input">Entity Name *</label>
-                                <input type="text" id="entity-name-input" class="form-input" required>
+                                <input type="text"
+                                       id="entity-name-input"
+                                       name="entity-name"
+                                       class="form-input"
+                                       required>
                             </div>
                         </div>
                         <div class="form-column">
                             <div class="form-group">
                                 <label class="form-label" for="entity-code-input">Entity Code *</label>
-                                <input type="text" id="entity-code-input" class="form-input" required>
+                                <input type="text"
+                                       id="entity-code-input"
+                                       name="entity-code"
+                                       class="form-input"
+                                       required>
                                 <small class="form-help">A unique code for this entity (e.g., TPF, TPF-ES)</small>
                             </div>
                         </div>
@@ -414,7 +598,9 @@
                         <div class="form-column">
                             <div class="form-group">
                                 <label class="form-label" for="entity-parent-select">Parent Entity</label>
-                                <select id="entity-parent-select" class="form-input">
+                                <select id="entity-parent-select"
+                                        name="entity-parent-id"
+                                        class="form-input">
                                     <option value="">-- No Parent (Top Level) --</option>
                                 </select>
                                 <small class="form-help">Select the parent organization for this entity</small>
@@ -423,7 +609,10 @@
                         <div class="form-column">
                             <div class="form-group checkbox-group">
                                 <label class="form-label">
-                                    <input type="checkbox" id="entity-consolidated-checkbox" class="form-checkbox">
+                                    <input type="checkbox"
+                                           id="entity-consolidated-checkbox"
+                                           name="entity-is-consolidated"
+                                           class="form-checkbox">
                                     Consolidate Children
                                 </label>
                                 <small class="form-help">When enabled, this entity will consolidate financial data from all child entities</small>
@@ -439,7 +628,9 @@
                         <div class="form-column">
                             <div class="form-group">
                                 <label class="form-label" for="entity-currency-select">Base Currency</label>
-                                <select id="entity-currency-select" class="form-input">
+                                <select id="entity-currency-select"
+                                        name="entity-currency"
+                                        class="form-input">
                                     <option value="USD">USD - US Dollar</option>
                                     <option value="EUR">EUR - Euro</option>
                                     <option value="GBP">GBP - British Pound</option>
@@ -451,7 +642,12 @@
                         <div class="form-column">
                             <div class="form-group">
                                 <label class="form-label" for="entity-fiscal-start-input">Fiscal Year Start</label>
-                                <input type="text" id="entity-fiscal-start-input" class="form-input" placeholder="MM-DD" value="01-01">
+                                <input type="text"
+                                       id="entity-fiscal-start-input"
+                                       name="entity-fiscal-start"
+                                       class="form-input"
+                                       placeholder="MM-DD"
+                                       value="01-01">
                                 <small class="form-help">Format: MM-DD (e.g., 01-01 for January 1st)</small>
                             </div>
                         </div>
@@ -465,7 +661,9 @@
                         <div class="form-column">
                             <div class="form-group">
                                 <label class="form-label" for="entity-status-select">Status</label>
-                                <select id="entity-status-select" class="form-input">
+                                <select id="entity-status-select"
+                                        name="entity-status"
+                                        class="form-input">
                                     <option value="Active">Active</option>
                                     <option value="Inactive">Inactive</option>
                                 </select>
@@ -479,7 +677,10 @@
                     <h4>Additional Information</h4>
                     <div class="form-group">
                         <label class="form-label" for="entity-description-textarea">Description</label>
-                        <textarea id="entity-description-textarea" class="form-input" rows="3"></textarea>
+                        <textarea id="entity-description-textarea"
+                                  name="entity-description"
+                                  class="form-input"
+                                  rows="3"></textarea>
                     </div>
                 </div>
 
@@ -492,9 +693,15 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button class="btn-secondary modal-close-btn" data-modal-id="entity-modal">Cancel</button>
-                <button class="action-button" id="btn-save-entity">Save Entity</button>
+                <button type="button"
+                        class="btn-secondary modal-close-btn"
+                        id="entity-modal-cancel"
+                        data-modal-id="entity-modal">Cancel</button>
+                <button type="submit"
+                        class="action-button"
+                        id="btn-save-entity">Save Entity</button>
             </div>
+            </form>
         </div>
     </div>
     <!-- ================= User Modal (Add / Edit) ================= -->

--- a/index.html
+++ b/index.html
@@ -549,7 +549,111 @@
             </form>
         </div>
     </div>
-    <div id="journal-entry-modal" class="modal-overlay"><div class="modal-dialog modal-dialog-lg"><div class="modal-header"><h3 class="modal-title" id="journal-entry-modal-title">New Journal Entry</h3><button class="modal-close-btn" data-modal-id="journal-entry-modal">&times;</button></div><div class="modal-body"><input type="hidden" id="edit-je-id-input"><div class="form-row"><div class="form-column"><div class="form-group"><label class="form-label" for="journal-entry-date">Date</label><input type="date" id="journal-entry-date" class="form-input"></div></div><div class="form-column"><div class="form-group"><label class="form-label" for="journal-entry-reference">Reference</label><input type="text" id="journal-entry-reference" class="form-input" readonly></div></div></div><div class="form-group"><label class="form-label" for="journal-entry-description">Description</label><input type="text" id="journal-entry-description" class="form-input" placeholder="Enter transaction description..."></div><div class="form-group"><label class="form-label"><input type="checkbox" id="journal-entry-is-inter-entity" class="form-input"> Is Inter-Entity Transfer?</label></div><div id="inter-entity-fields-container" class="inter-entity-fields"><div class="form-row"><div class="form-column"><div class="form-group"><label class="form-label" for="journal-entry-target-entity">Target Entity</label><select id="journal-entry-target-entity" class="form-input"><option value="">Select Target Entity...</option></select></div></div><div class="form-column"><div class="form-group"><label class="form-label" for="journal-entry-matching-tx-id">Matching Transaction ID (Optional)</label><input type="text" id="journal-entry-matching-tx-id" class="form-input" placeholder="Auto-generated if blank"></div></div></div></div><h4 style="margin: 20px 0 10px 0;">Journal Entry Lines</h4><table class="data-table" id="journal-lines-table"><thead><tr><th>Account</th><th>Fund</th><th>Debit</th><th>Credit</th><th>Description</th><th>Action</th></tr></thead><tbody id="journal-lines"></tbody></table><button id="add-journal-line" class="btn-secondary" style="margin-top: 10px;">Add Line</button><div class="totals-summary"><div class="form-group"><label class="form-label">Total Debits</label><input type="text" id="journal-total-debits" class="form-input" value="$0.00" readonly></div><div class="form-group"><label class="form-label">Total Credits</label><input type="text" id="journal-total-credits" class="form-input" value="$0.00" readonly></div><div class="form-group"><label class="form-label">Difference</label><input type="text" id="journal-difference" class="form-input" value="$0.00" readonly></div></div></div><div class="modal-footer"><button class="btn-secondary modal-close-btn" data-modal-id="journal-entry-modal">Cancel</button><button class="action-button" id="btn-save-journal-draft">Save as Draft</button><button class="action-button" id="btn-save-journal-post">Save & Post</button></div></div></div>
+    <!-- ================= Journal Entry Modal (aligned with app-modals.js) ================= -->
+    <div id="journal-entry-modal" class="modal-overlay">
+        <div class="modal-dialog modal-dialog-lg">
+            <div class="modal-header">
+                <h3 class="modal-title" id="journal-entry-modal-title">Journal Entry</h3>
+                <!-- Close button with explicit id -->
+                <button class="modal-close-btn"
+                        id="journal-entry-modal-close"
+                        data-modal-id="journal-entry-modal">&times;</button>
+            </div>
+
+            <!-- Form wrapper required for submit handling in app-modals.js -->
+            <form id="journal-entry-modal-form">
+                <div class="modal-body">
+                    <input type="hidden" id="edit-je-id-input">
+
+                    <!-- Top-level meta fields -->
+                    <div class="form-row">
+                        <div class="form-column">
+                            <div class="form-group">
+                                <label class="form-label" for="journal-entry-date">Date</label>
+                                <input type="date"
+                                       id="journal-entry-date"
+                                       name="journal-entry-date"
+                                       class="form-input"
+                                       required>
+                            </div>
+                        </div>
+                        <div class="form-column">
+                            <div class="form-group">
+                                <label class="form-label" for="journal-entry-reference">Reference</label>
+                                <input type="text"
+                                       id="journal-entry-reference"
+                                       name="journal-entry-reference"
+                                       class="form-input"
+                                       readonly>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-column">
+                            <div class="form-group">
+                                <label class="form-label" for="journal-entry-entity-id">Entity</label>
+                                <select id="journal-entry-entity-id"
+                                        name="journal-entry-entity-id"
+                                        class="form-input">
+                                    <option value="">Select Entity…</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-column">
+                            <div class="form-group">
+                                <label class="form-label" for="journal-entry-type">Type</label>
+                                <select id="journal-entry-type"
+                                        name="journal-entry-type"
+                                        class="form-input">
+                                    <option value="General">General</option>
+                                    <option value="Revenue">Revenue</option>
+                                    <option value="Expense">Expense</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label" for="journal-entry-description">Description</label>
+                        <input type="text"
+                               id="journal-entry-description"
+                               name="journal-entry-description"
+                               class="form-input">
+                    </div>
+
+                    <!-- Line-items container (dynamically populated) -->
+                    <h4 style="margin: 20px 0 10px 0;">Journal Entry Line Items</h4>
+                    <div id="journal-entry-line-items" class="dynamic-container"></div>
+                    <button id="add-line-item-btn" type="button" class="btn-secondary" style="margin-top:10px;">
+                        Add Line Item
+                    </button>
+
+                    <!-- Totals -->
+                    <div class="totals-summary" style="margin-top:15px;">
+                        <div>Total Debits: <span id="journal-entry-total-debit">$0.00</span></div>
+                        <div>Total Credits: <span id="journal-entry-total-credit">$0.00</span></div>
+                        <div>Balance: <span id="journal-entry-balance">$0.00</span></div>
+                    </div>
+                </div><!-- /.modal-body -->
+
+                <div class="modal-footer">
+                    <button type="button"
+                            class="btn-secondary modal-close-btn"
+                            id="journal-entry-modal-cancel"
+                            data-modal-id="journal-entry-modal">Cancel</button>
+
+                    <button type="submit"
+                            class="action-button"
+                            id="save-journal-entry-btn">Save Entry</button>
+
+                    <button type="button"
+                            class="action-button"
+                            id="post-journal-entry-btn">Post Entry</button>
+                </div>
+            </form><!-- /form -->
+        </div>
+    </div>
     <!-- Enhanced Entity Modal -->
     <div id="entity-modal" class="modal-overlay">
         <div class="modal-dialog modal-dialog-lg">

--- a/src/js/app-main.js
+++ b/src/js/app-main.js
@@ -541,22 +541,6 @@ function initializeAddButtons() {
     
     // Add fund button
     const addFundBtn = document.getElementById('btnAddFund');
- * Initialize print buttons (currently only Dashboard “Print Report”)
- * Adds the listener once and stores a flag on the element so we don’t
- * double-bind if initializePageElements() is called again.
- */
-function initializePrintButtons() {
-    const printBtn = document.getElementById('btnPrintDashboard');
-    if (printBtn && !printBtn.__bound) {
-        printBtn.__bound = true;
-        printBtn.addEventListener('click', () => {
-            // Basic – rely on print media CSS for layout
-            window.print();
-        });
-    }
-}
-
-/**
     if (addFundBtn) {
         addFundBtn.addEventListener('click', () => {
             openFundModal();

--- a/src/js/app-main.js
+++ b/src/js/app-main.js
@@ -522,6 +522,9 @@ function initializePageElements() {
     
     // Initialize filter selects
     initializeFilterSelects();
+
+    // Initialize print buttons (e.g., Dashboard → “Print Report”)
+    initializePrintButtons();
 }
 
 /**
@@ -538,6 +541,22 @@ function initializeAddButtons() {
     
     // Add fund button
     const addFundBtn = document.getElementById('btnAddFund');
+ * Initialize print buttons (currently only Dashboard “Print Report”)
+ * Adds the listener once and stores a flag on the element so we don’t
+ * double-bind if initializePageElements() is called again.
+ */
+function initializePrintButtons() {
+    const printBtn = document.getElementById('btnPrintDashboard');
+    if (printBtn && !printBtn.__bound) {
+        printBtn.__bound = true;
+        printBtn.addEventListener('click', () => {
+            // Basic – rely on print media CSS for layout
+            window.print();
+        });
+    }
+}
+
+/**
     if (addFundBtn) {
         addFundBtn.addEventListener('click', () => {
             openFundModal();
@@ -574,6 +593,18 @@ function initializeAddButtons() {
         addBankAccountBtn.addEventListener('click', () => {
             openBankAccountModal();
         });
+    }
+}
+
+/**
+ * Initialize print buttons (currently only Dashboard "Print Report").
+ * Ensures each target element is bound only once.
+ */
+function initializePrintButtons() {
+    const printBtn = document.getElementById('btnPrintDashboard');
+    if (printBtn && !printBtn.__bound) {
+        printBtn.__bound = true;
+        printBtn.addEventListener('click', () => window.print());
     }
 }
 

--- a/src/js/app-main.js
+++ b/src/js/app-main.js
@@ -253,6 +253,7 @@ function showPage(pageId) {
         case 'fund-reports':
             initializeFundReportsTabs();
             updateFundReportsFilters();
+            initializeFundReportsActions();
             break;
     }
 }
@@ -398,6 +399,279 @@ function initializeFundReportsTabs() {
     });
 
     // ensure default active remains selected on first bind
+}
+
+/**
+ * Bind Generate Report button for Fund Reports page (runs once)
+ */
+function initializeFundReportsActions() {
+    const generateBtn = document.getElementById('fund-reports-generate');
+    if (!generateBtn || generateBtn.__bound) return;
+    generateBtn.__bound = true;
+
+    // Set sensible default dates on first bind
+    const inputStart = document.getElementById('fund-reports-date-start');
+    const inputEnd   = document.getElementById('fund-reports-date-end');
+    if (inputStart && !inputStart.value) {
+        const now = new Date();
+        inputStart.value = `${now.getFullYear()}-01-01`;
+    }
+    if (inputEnd && !inputEnd.value) {
+        inputEnd.value = new Date().toISOString().substring(0, 10);
+    }
+
+    generateBtn.addEventListener('click', generateFundReports);
+}
+
+/**
+ * Main dispatcher for Fund Reports
+ */
+async function generateFundReports() {
+    const fundSelect = document.getElementById('fund-reports-fund-select');
+    const fromInput  = document.getElementById('fund-reports-date-start');
+    const toInput    = document.getElementById('fund-reports-date-end');
+
+    const fundId   = fundSelect ? fundSelect.value : '';
+    const fromDate = fromInput ? fromInput.value : '';
+    const toDate   = toInput ? toInput.value : '';
+
+    const activeTabId = getActiveFundReportTabId();
+
+    // Tabs that require a fund
+    const needsFund = [
+        'fund-balance-report',
+        'fund-activity-report',
+        'fund-statement-report'
+    ];
+    if (needsFund.includes(activeTabId) && !fundId) {
+        showToast('Please select a fund first', 'warning');
+        return;
+    }
+
+    try {
+        switch (activeTabId) {
+            case 'fund-balance-report':
+                renderFundBalanceReport(fundId);
+                break;
+            case 'fund-activity-report':
+                await renderFundActivityReport(fundId, fromDate, toDate);
+                break;
+            case 'fund-statement-report':
+                await renderFundStatementReport(fundId, fromDate, toDate);
+                break;
+            case 'funds-comparison-report':
+                renderFundsComparisonReport();
+                break;
+            default:
+                console.warn('Unknown Fund Report tab:', activeTabId);
+        }
+    } catch (err) {
+        console.error('Error generating fund report:', err);
+        showToast('Error generating report', 'error');
+    }
+}
+
+/**
+ * Returns ID of active tab panel inside Fund Reports
+ */
+function getActiveFundReportTabId() {
+    const activePanel = document
+        .querySelector('#fund-reports-page .tab-panel.active');
+    return activePanel ? activePanel.id : '';
+}
+
+/* ------------------------------------------------------------------
+ * Renderers
+ * -----------------------------------------------------------------*/
+
+function renderFundBalanceReport(fundId) {
+    const container = document.getElementById('fund-balance-content');
+    if (!container) return;
+
+    const fund = appState.funds.find(f => String(f.id) === String(fundId));
+    if (!fund) {
+        container.innerHTML = '<p class="text-center">Fund not found.</p>';
+        return;
+    }
+
+    const entityName =
+        appState.entities.find(e => e.id === fund.entity_id)?.name || 'Unknown';
+
+    container.innerHTML = `
+        <table class="data-table">
+            <tbody>
+                <tr><th>Fund</th><td>${fund.code} - ${fund.name}</td></tr>
+                <tr><th>Entity</th><td>${entityName}</td></tr>
+                <tr><th>Type</th><td>${fund.type || 'N/A'}</td></tr>
+                <tr><th>Balance</th><td>${formatCurrency(fund.balance)}</td></tr>
+                <tr><th>As of</th><td>${formatDate(new Date())}</td></tr>
+            </tbody>
+        </table>
+    `;
+}
+
+/**
+ * Fetch journal entry lines affecting the given fund within date range
+ */
+async function loadFundActivityLines(fundId, fromDate, toDate) {
+    const params = [];
+    if (fromDate) params.push(`from_date=${fromDate}`);
+    if (toDate)   params.push(`to_date=${toDate}`);
+    const qs = params.length ? `?${params.join('&')}` : '';
+
+    const entries = await fetchData(`journal-entries${qs}`);
+    const lines = [];
+
+    for (const entry of entries) {
+        const entryLines = await fetchData(`journal-entries/${entry.id}/lines`);
+        entryLines
+            .filter(l => String(l.fund_id) === String(fundId))
+            .forEach(l => {
+                lines.push({
+                    entry_date: entry.entry_date,
+                    description:
+                        l.description || entry.description || '—',
+                    account_code: l.account_code,
+                    account_name: l.account_name,
+                    debit: parseFloat(l.debit || 0),
+                    credit: parseFloat(l.credit || 0)
+                });
+            });
+    }
+    return lines;
+}
+
+async function renderFundActivityReport(fundId, fromDate, toDate) {
+    const container = document.getElementById('fund-activity-content');
+    if (!container) return;
+
+    container.innerHTML = '<p>Loading activity...</p>';
+    const lines = await loadFundActivityLines(fundId, fromDate, toDate);
+
+    if (lines.length === 0) {
+        container.innerHTML =
+            '<p class="text-center">No activity found for selected period.</p>';
+        return;
+    }
+
+    let totalDebit = 0;
+    let totalCredit = 0;
+
+    const rowsHtml = lines
+        .sort((a, b) => new Date(a.entry_date) - new Date(b.entry_date))
+        .map(l => {
+            totalDebit += l.debit;
+            totalCredit += l.credit;
+            return `<tr>
+                <td>${formatDate(l.entry_date)}</td>
+                <td>${l.account_code} - ${l.account_name}</td>
+                <td>${l.description}</td>
+                <td class="text-right">${l.debit ? formatCurrency(l.debit) : ''}</td>
+                <td class="text-right">${l.credit ? formatCurrency(l.credit) : ''}</td>
+            </tr>`;
+        })
+        .join('');
+
+    container.innerHTML = `
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Date</th><th>Account</th><th>Description</th>
+                    <th class="text-right">Debit</th>
+                    <th class="text-right">Credit</th>
+                </tr>
+            </thead>
+            <tbody>${rowsHtml}</tbody>
+            <tfoot>
+                <tr>
+                    <th colspan="3" class="text-right">Total</th>
+                    <th class="text-right">${formatCurrency(totalDebit)}</th>
+                    <th class="text-right">${formatCurrency(totalCredit)}</th>
+                </tr>
+            </tfoot>
+        </table>
+    `;
+}
+
+async function renderFundStatementReport(fundId, fromDate, toDate) {
+    const container = document.getElementById('fund-statement-content');
+    if (!container) return;
+
+    container.innerHTML = '<p>Loading statement...</p>';
+    const lines = await loadFundActivityLines(fundId, fromDate, toDate);
+
+    if (lines.length === 0) {
+        container.innerHTML =
+            '<p class="text-center">No activity to build statement.</p>';
+        return;
+    }
+
+    // Map account_code to type via appState.accounts
+    const acctTypeMap = {};
+    appState.accounts.forEach(a => (acctTypeMap[a.code] = a.type));
+
+    let revenue = 0;
+    let expense = 0;
+
+    lines.forEach(l => {
+        const aType = acctTypeMap[l.account_code] || '';
+        if (aType === 'Revenue') revenue += l.credit - l.debit;
+        if (aType === 'Expense') expense += l.debit - l.credit;
+    });
+
+    const net = revenue - expense;
+
+    container.innerHTML = `
+        <table class="data-table">
+            <tbody>
+                <tr><th>Total Revenue</th><td class="text-right">${formatCurrency(revenue)}</td></tr>
+                <tr><th>Total Expense</th><td class="text-right">${formatCurrency(expense)}</td></tr>
+                <tr class="font-weight-bold"><th>Net Change</th><td class="text-right">${formatCurrency(net)}</td></tr>
+            </tbody>
+        </table>
+    `;
+}
+
+function renderFundsComparisonReport() {
+    const container = document.getElementById('funds-comparison-content');
+    if (!container) return;
+
+    const funds = getRelevantFunds();
+    if (funds.length === 0) {
+        container.innerHTML =
+            '<p class="text-center">No funds available for comparison.</p>';
+        return;
+    }
+
+    const total = funds.reduce((s, f) => s + parseFloat(f.balance || 0), 0);
+
+    const rowsHtml = funds
+        .sort((a, b) => parseFloat(b.balance) - parseFloat(a.balance))
+        .map(f => {
+            const pct = total ? formatPercentage(f.balance, total) : '—';
+            return `<tr>
+                <td>${f.code} - ${f.name}</td>
+                <td>${f.type || 'N/A'}</td>
+                <td class="text-right">${formatCurrency(f.balance)}</td>
+                <td class="text-right">${pct}</td>
+            </tr>`;
+        })
+        .join('');
+
+    container.innerHTML = `
+        <table class="data-table">
+            <thead>
+                <tr><th>Fund</th><th>Type</th><th class="text-right">Balance</th><th class="text-right">% of Total</th></tr>
+            </thead>
+            <tbody>${rowsHtml}</tbody>
+            <tfoot>
+                <tr><th colspan="2" class="text-right">Total</th>
+                    <th class="text-right">${formatCurrency(total)}</th>
+                    <th></th>
+                </tr>
+            </tfoot>
+        </table>
+    `;
 }
 
 /**

--- a/src/js/check-printing-core.js
+++ b/src/js/check-printing-core.js
@@ -648,6 +648,27 @@ function showToast(type, title, message, timeout = 4000) {
     }, timeout);
 }
 
+// --- Global toast shim for compatibility with app.js and other modules ---
+try {
+    // Preserve reference to the local implementation
+    const _localShowToast = showToast;
+
+    // Expose a global wrapper that matches the simpler (message, type) signature
+    window.showToast = function (message, type = 'info') {
+        try {
+            const t = (typeof type === 'string' && type.trim()) ? type.trim() : 'info';
+            const title = t.charAt(0).toUpperCase() + t.slice(1);
+            _localShowToast(t, title, message);
+        } catch (err) {
+            // Fail silently but log for debugging
+            console.error('Toast shim failed:', err);
+        }
+    };
+} catch (e) {
+    // In very rare cases (frozen window) just log the problem
+    console.warn('Unable to install global toast shim:', e);
+}
+
 // ========================================================
 // Event Listeners
 // ========================================================

--- a/src/js/vendor-payments.js
+++ b/src/js/vendor-payments.js
@@ -347,10 +347,11 @@ async function fetchNachaSettings() {
         ];
         
         settingsSelects.forEach(select => {
-            if (!select) return;
+            // Guard: make sure select element and its options collection exist
+            if (!select || !select.options) return;
             
             // Clear existing options except the first one
-            while (select.options.length > 1) {
+            while ((select.options?.length || 0) > 1) {
                 select.remove(1);
             }
             
@@ -358,7 +359,9 @@ async function fetchNachaSettings() {
             nachaSettings.forEach(setting => {
                 const option = document.createElement('option');
                 option.value = setting.id;
-                option.textContent = `${setting.company_name} (${setting.company_entry_description})`;
+                option.textContent = setting.company_entry_description
+                    ? `${setting.company_name} (${setting.company_entry_description})`
+                    : setting.company_name;
                 select.appendChild(option);
             });
         });

--- a/src/js/vendor-payments.js
+++ b/src/js/vendor-payments.js
@@ -317,8 +317,27 @@ async function fetchNachaSettings() {
             }
             throw new Error(`HTTP ${response.status}: ${response.statusText}`);
         }
-        nachaSettings = await response.json();
-        console.log('NACHA settings fetched successfully:', nachaSettings.length, 'settings');
+        /* ------------------------------------------------------------------
+         * Robust parsing / shape-normalisation
+         * ----------------------------------------------------------------*/
+        let data;
+        try {
+            data = await response.json();
+        } catch (_) {
+            data = [];
+        }
+
+        if (Array.isArray(data)) {
+            nachaSettings = data;
+        } else if (data && Array.isArray(data.rows)) {
+            nachaSettings = data.rows;
+        } else if (data && Array.isArray(data.data)) {
+            nachaSettings = data.data;
+        } else {
+            nachaSettings = [];
+        }
+
+        console.log('NACHA settings fetched successfully:', (nachaSettings?.length || 0), 'settings');
         renderNachaSettingsTable();
         
         // Populate NACHA settings dropdowns

--- a/src/js/vendor-payments.js
+++ b/src/js/vendor-payments.js
@@ -12,6 +12,7 @@ const API_BASE_URL = devPorts.includes(window.location.port)
 // Global variables
 let currentVendor = null;
 let currentBatch = null;
+let currentNachaSettings = null;
 let entities = [];
 let funds = [];
 let bankAccounts = [];
@@ -43,6 +44,10 @@ function showToast(title, message, isError = false) {
     
     const bsToast = new bootstrap.Toast(toast);
     bsToast.show();
+}
+
+function confirmDialog(message) {
+    return window.confirm(message);
 }
 
 function formatCurrency(amount) {
@@ -100,6 +105,7 @@ async function fetchEntities() {
             document.getElementById('entityId'),
             document.getElementById('editEntityId'),
             document.getElementById('batchEntityId'),
+            document.getElementById('editBatchEntityId'),
             document.getElementById('settingsEntityId'),
             document.getElementById('editSettingsEntityId')
         ];
@@ -144,7 +150,8 @@ async function fetchFunds(entityId = null) {
         
         // Populate fund dropdowns
         const fundSelects = [
-            document.getElementById('batchFundId')
+            document.getElementById('batchFundId'),
+            document.getElementById('editBatchFundId')
         ];
         
         fundSelects.forEach(select => {
@@ -316,7 +323,8 @@ async function fetchNachaSettings() {
         
         // Populate NACHA settings dropdowns
         const settingsSelects = [
-            document.getElementById('nachaSettingsId')
+            document.getElementById('nachaSettingsId'),
+            document.getElementById('editNachaSettingsId')
         ];
         
         settingsSelects.forEach(select => {
@@ -393,9 +401,9 @@ async function fetchNachaFiles() {
     }
 }
 
-// Render functions (stubs - these would contain the actual rendering logic)
+// Render functions
 function renderBatchesTable(batches) {
-    console.log('Rendering batches table with', batches.length, 'batches');
+    console.log('Rendering batches table with', batches?.length || 0, 'batches');
     const tableBody = document.getElementById('batchesTableBody');
     if (!tableBody) return;
     
@@ -409,17 +417,15 @@ function renderBatchesTable(batches) {
         return;
     }
     
-    // This would contain the full batches table rendering logic
-
     batches.forEach(batch => {
         const row = document.createElement('tr');
+        row.dataset.id = batch.id;
 
         /* ----------- prepare values with graceful fall-backs ----------- */
         const batchNo    = batch.batch_number ?? '(n/a)';
-        const entityName = batch.entity_name ?? '';
-        const nachaName  = batch.nacha_company_name ?? '—';
         const batchDate  = formatDate(batch.batch_date);
-        const effDate    = formatDate(batch.effective_date);
+        const description = batch.description ?? '';
+        const entityName = batch.entity_name ?? '';
         const amountFmt  = formatCurrency(parseFloat(batch.total_amount ?? 0));
         const itemsTotal = batch.total_items ?? 0;
 
@@ -428,24 +434,45 @@ function renderBatchesTable(batches) {
         const statusBadge = `<span class="badge ${statusCls} text-capitalize">${(batch.status || '')
                                     .replace('_', ' ')}</span>`;
 
+        /* actions buttons */
+        const actions = `
+            <div class="btn-group btn-group-sm">
+                <button class="btn btn-outline-primary btn-edit-batch" data-id="${batch.id}" title="Edit Batch">
+                    <i class="fas fa-edit"></i>
+                </button>
+                <button class="btn btn-outline-danger btn-delete-batch" data-id="${batch.id}" title="Delete Batch">
+                    <i class="fas fa-trash"></i>
+                </button>
+            </div>
+        `;
+
         /* ----------- build row html ----------- */
         row.innerHTML = `
             <td>${batchNo}</td>
-            <td>${entityName}</td>
-            <td>${nachaName}</td>
             <td>${batchDate}</td>
-            <td>${effDate}</td>
-            <td>${statusBadge}</td>
+            <td>${description}</td>
+            <td>${entityName}</td>
             <td class="text-end">${amountFmt}</td>
             <td class="text-end">${itemsTotal}</td>
+            <td>${statusBadge}</td>
+            <td class="text-center">${actions}</td>
         `;
 
         tableBody.appendChild(row);
     });
+
+    // Add event listeners to action buttons
+    document.querySelectorAll('.btn-edit-batch').forEach(btn => {
+        btn.addEventListener('click', () => openEditBatch(btn.dataset.id));
+    });
+
+    document.querySelectorAll('.btn-delete-batch').forEach(btn => {
+        btn.addEventListener('click', () => deletePaymentBatch(btn.dataset.id));
+    });
 }
 
 function renderVendorsTable() {
-    console.log('Rendering vendors table with', vendors.length, 'vendors');
+    console.log('Rendering vendors table with', vendors?.length || 0, 'vendors');
     const tableBody = document.getElementById('vendorsTableBody');
     if (!tableBody) return;
     
@@ -464,16 +491,29 @@ function renderVendorsTable() {
      * ----------------------------------------------------------------*/
     vendors.forEach(vendor => {
         const row = document.createElement('tr');
+        row.dataset.id = vendor.id;
 
         const code        = vendor.vendor_code ?? '';
         const name        = vendor.name ?? '';
         const contactName = vendor.contact_name ?? '—';
         const email       = vendor.email ?? '—';
         const phone       = vendor.phone ?? '—';
+        const bankAccounts = '—'; // Placeholder for bank accounts count
         const statusCls   = getStatusBadgeClass(vendor.status);
         const statusBadge = `<span class="badge ${statusCls} text-capitalize">${(vendor.status || '')
                                 .replace('_', ' ')}</span>`;
-        const createdDate = formatDate(vendor.created_at);
+
+        /* actions buttons */
+        const actions = `
+            <div class="btn-group btn-group-sm">
+                <button class="btn btn-outline-primary btn-edit-vendor" data-id="${vendor.id}" title="Edit Vendor">
+                    <i class="fas fa-edit"></i>
+                </button>
+                <button class="btn btn-outline-danger btn-delete-vendor" data-id="${vendor.id}" title="Delete Vendor">
+                    <i class="fas fa-trash"></i>
+                </button>
+            </div>
+        `;
 
         row.innerHTML = `
             <td>${code}</td>
@@ -481,16 +521,26 @@ function renderVendorsTable() {
             <td>${contactName}</td>
             <td>${email}</td>
             <td>${phone}</td>
+            <td>${bankAccounts}</td>
             <td>${statusBadge}</td>
-            <td>${createdDate}</td>
+            <td class="text-center">${actions}</td>
         `;
 
         tableBody.appendChild(row);
     });
+
+    // Add event listeners to action buttons
+    document.querySelectorAll('.btn-edit-vendor').forEach(btn => {
+        btn.addEventListener('click', () => openEditVendor(btn.dataset.id));
+    });
+
+    document.querySelectorAll('.btn-delete-vendor').forEach(btn => {
+        btn.addEventListener('click', () => deleteVendor(btn.dataset.id));
+    });
 }
 
 function renderNachaSettingsTable() {
-    console.log('Rendering NACHA settings table with', nachaSettings.length, 'settings');
+    console.log('Rendering NACHA settings table with', nachaSettings?.length || 0, 'settings');
     const tableBody = document.getElementById('nachaSettingsTableBody');
     if (!tableBody) return;
     
@@ -509,32 +559,53 @@ function renderNachaSettingsTable() {
      * ----------------------------------------------------------------*/
     nachaSettings.forEach(setting => {
         const row = document.createElement('tr');
+        row.dataset.id = setting.id;
 
         /* graceful fall-backs */
-        const entityName  = setting.entity_name  ?? '—';
         const companyName = setting.company_name ?? '';
         const companyId   = setting.company_id   ?? '';
         const dfiId       = setting.originating_dfi_id ?? '';
         const entryDesc   = setting.company_entry_description ?? '';
+        const settlementAccount = setting.settlement_account_name ?? '—';
         const prodFlag    = setting.is_production ? 'Yes' : 'No';
-        const createdDate = formatDate(setting.created_at);
+
+        /* actions buttons */
+        const actions = `
+            <div class="btn-group btn-group-sm">
+                <button class="btn btn-outline-primary btn-edit-nacha-settings" data-id="${setting.id}" title="Edit Settings">
+                    <i class="fas fa-edit"></i>
+                </button>
+                <button class="btn btn-outline-danger btn-delete-nacha-settings" data-id="${setting.id}" title="Delete Settings">
+                    <i class="fas fa-trash"></i>
+                </button>
+            </div>
+        `;
 
         row.innerHTML = `
-            <td>${entityName}</td>
             <td>${companyName}</td>
             <td>${companyId}</td>
             <td>${dfiId}</td>
             <td>${entryDesc}</td>
+            <td>${settlementAccount}</td>
             <td class="text-center">${prodFlag}</td>
-            <td>${createdDate}</td>
+            <td class="text-center">${actions}</td>
         `;
 
         tableBody.appendChild(row);
     });
+
+    // Add event listeners to action buttons
+    document.querySelectorAll('.btn-edit-nacha-settings').forEach(btn => {
+        btn.addEventListener('click', () => openEditNachaSettings(btn.dataset.id));
+    });
+
+    document.querySelectorAll('.btn-delete-nacha-settings').forEach(btn => {
+        btn.addEventListener('click', () => deleteNachaSettings(btn.dataset.id));
+    });
 }
 
 function renderNachaFilesTable(files) {
-    console.log('Rendering NACHA files table with', files.length, 'files');
+    console.log('Rendering NACHA files table with', files?.length || 0, 'files');
     const tableBody = document.getElementById('nachaFilesTableBody');
     if (!tableBody) return;
     
@@ -591,7 +662,334 @@ function renderNachaFilesTable(files) {
 }
 
 /* ---------------------------------------------------------------------------
- * PAYMENT BATCH CREATION
+ * VENDOR CRUD OPERATIONS
+ * -------------------------------------------------------------------------*/
+
+// Open edit vendor modal
+function openEditVendor(vendorId) {
+    const vendor = vendors.find(v => v.id == vendorId);
+    if (!vendor) {
+        showToast('Error', 'Vendor not found', true);
+        return;
+    }
+
+    currentVendor = vendor;
+
+    // Populate form fields
+    document.getElementById('editVendorId').value = vendor.id;
+    document.getElementById('editEntityId').value = vendor.entity_id;
+    document.getElementById('editVendorCode').value = vendor.vendor_code;
+    document.getElementById('editVendorName').value = vendor.name;
+    document.getElementById('editContactName').value = vendor.contact_name || '';
+    document.getElementById('editVendorEmail').value = vendor.email || '';
+    document.getElementById('editVendorPhone').value = vendor.phone || '';
+    document.getElementById('editVendorStatus').value = vendor.status || 'active';
+    document.getElementById('editVendorNotes').value = vendor.notes || '';
+
+    // Show the modal
+    const modal = new bootstrap.Modal(document.getElementById('editVendorModal'));
+    modal.show();
+}
+
+// Create vendor
+async function createVendor(vendorData) {
+    try {
+        console.log('[createVendor] Creating vendor…', vendorData);
+        showLoading();
+
+        const res = await fetch(`${API_BASE_URL}/api/vendors`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify(vendorData)
+        });
+
+        if (!res.ok) {
+            let serverMsg = '';
+            try {
+                const ctype = res.headers.get('content-type') || '';
+                serverMsg = ctype.includes('application/json')
+                    ? (await res.json()).error ?? ''
+                    : await res.text();
+            } catch (_) { /* ignore body read errors */ }
+            throw new Error(`HTTP ${res.status}: ${res.statusText}${serverMsg ? ' – ' + serverMsg : ''}`);
+        }
+
+        const created = await res.json();
+        console.log('[createVendor] Success:', created);
+        showToast('Success', 'Vendor created successfully');
+
+        // Refresh list
+        await fetchVendors();
+
+        // Close modal & reset form
+        const modalEl = document.getElementById('createVendorModal');
+        if (modalEl) bootstrap.Modal.getInstance(modalEl)?.hide();
+        document.getElementById('createVendorForm')?.reset();
+
+        return created;
+    } catch (err) {
+        console.error('[createVendor] Error:', err);
+        showToast('Error', 'Failed to create vendor: ' + err.message, true);
+        throw err;
+    } finally {
+        hideLoading();
+    }
+}
+
+// Update vendor
+async function updateVendor(vendorId, vendorData) {
+    try {
+        console.log('[updateVendor] Updating vendor…', vendorId, vendorData);
+        showLoading();
+
+        const res = await fetch(`${API_BASE_URL}/api/vendors/${vendorId}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify(vendorData)
+        });
+
+        if (!res.ok) {
+            let serverMsg = '';
+            try {
+                const ctype = res.headers.get('content-type') || '';
+                serverMsg = ctype.includes('application/json')
+                    ? (await res.json()).error ?? ''
+                    : await res.text();
+            } catch (_) { /* ignore body read errors */ }
+            throw new Error(`HTTP ${res.status}: ${res.statusText}${serverMsg ? ' – ' + serverMsg : ''}`);
+        }
+
+        const updated = await res.json();
+        console.log('[updateVendor] Success:', updated);
+        showToast('Success', 'Vendor updated successfully');
+
+        // Refresh list
+        await fetchVendors();
+
+        // Close modal
+        const modalEl = document.getElementById('editVendorModal');
+        if (modalEl) bootstrap.Modal.getInstance(modalEl)?.hide();
+
+        return updated;
+    } catch (err) {
+        console.error('[updateVendor] Error:', err);
+        showToast('Error', 'Failed to update vendor: ' + err.message, true);
+        throw err;
+    } finally {
+        hideLoading();
+    }
+}
+
+// Delete vendor
+async function deleteVendor(vendorId) {
+    if (!confirmDialog('Are you sure you want to delete this vendor? This action cannot be undone.')) {
+        return;
+    }
+
+    try {
+        console.log('[deleteVendor] Deleting vendor…', vendorId);
+        showLoading();
+
+        const res = await fetch(`${API_BASE_URL}/api/vendors/${vendorId}`, {
+            method: 'DELETE',
+            credentials: 'include'
+        });
+
+        if (!res.ok) {
+            let serverMsg = '';
+            try {
+                const ctype = res.headers.get('content-type') || '';
+                serverMsg = ctype.includes('application/json')
+                    ? (await res.json()).error ?? ''
+                    : await res.text();
+            } catch (_) { /* ignore body read errors */ }
+            throw new Error(`HTTP ${res.status}: ${res.statusText}${serverMsg ? ' – ' + serverMsg : ''}`);
+        }
+
+        console.log('[deleteVendor] Success');
+        showToast('Success', 'Vendor deleted successfully');
+
+        // Refresh list
+        await fetchVendors();
+
+        // Close modal if open
+        const modalEl = document.getElementById('editVendorModal');
+        if (modalEl) bootstrap.Modal.getInstance(modalEl)?.hide();
+    } catch (err) {
+        console.error('[deleteVendor] Error:', err);
+        showToast('Error', 'Failed to delete vendor: ' + err.message, true);
+    } finally {
+        hideLoading();
+    }
+}
+
+/* ---------------------------------------------------------------------------
+ * NACHA SETTINGS CRUD OPERATIONS
+ * -------------------------------------------------------------------------*/
+
+// Open edit NACHA settings modal
+function openEditNachaSettings(settingsId) {
+    const settings = nachaSettings.find(s => s.id == settingsId);
+    if (!settings) {
+        showToast('Error', 'NACHA settings not found', true);
+        return;
+    }
+
+    currentNachaSettings = settings;
+
+    // Populate form fields
+    document.getElementById('editNachaSettingsId').value = settings.id;
+    document.getElementById('editSettingsEntityId').value = settings.entity_id;
+    document.getElementById('editSettlementAccountId').value = settings.settlement_account_id || '';
+    document.getElementById('editCompanyName').value = settings.company_name;
+    document.getElementById('editCompanyId').value = settings.company_id;
+    document.getElementById('editOriginatingDfiId').value = settings.originating_dfi_id;
+    document.getElementById('editCompanyEntryDescription').value = settings.company_entry_description || '';
+    document.getElementById('editIsProduction').checked = settings.is_production || false;
+
+    // Show the modal
+    const modal = new bootstrap.Modal(document.getElementById('editNachaSettingsModal'));
+    modal.show();
+}
+
+// Create NACHA settings
+async function createNachaSettings(settingsData) {
+    try {
+        console.log('[createNachaSettings] Creating NACHA settings…', settingsData);
+        showLoading();
+
+        const res = await fetch(`${API_BASE_URL}/api/nacha-settings`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify(settingsData)
+        });
+
+        if (!res.ok) {
+            let serverMsg = '';
+            try {
+                const ctype = res.headers.get('content-type') || '';
+                serverMsg = ctype.includes('application/json')
+                    ? (await res.json()).error ?? ''
+                    : await res.text();
+            } catch (_) { /* ignore body read errors */ }
+            throw new Error(`HTTP ${res.status}: ${res.statusText}${serverMsg ? ' – ' + serverMsg : ''}`);
+        }
+
+        const created = await res.json();
+        console.log('[createNachaSettings] Success:', created);
+        showToast('Success', 'NACHA settings created successfully');
+
+        // Refresh list
+        await fetchNachaSettings();
+
+        // Close modal & reset form
+        const modalEl = document.getElementById('createNachaSettingsModal');
+        if (modalEl) bootstrap.Modal.getInstance(modalEl)?.hide();
+        document.getElementById('createNachaSettingsForm')?.reset();
+
+        return created;
+    } catch (err) {
+        console.error('[createNachaSettings] Error:', err);
+        showToast('Error', 'Failed to create NACHA settings: ' + err.message, true);
+        throw err;
+    } finally {
+        hideLoading();
+    }
+}
+
+// Update NACHA settings
+async function updateNachaSettings(settingsId, settingsData) {
+    try {
+        console.log('[updateNachaSettings] Updating NACHA settings…', settingsId, settingsData);
+        showLoading();
+
+        const res = await fetch(`${API_BASE_URL}/api/nacha-settings/${settingsId}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify(settingsData)
+        });
+
+        if (!res.ok) {
+            let serverMsg = '';
+            try {
+                const ctype = res.headers.get('content-type') || '';
+                serverMsg = ctype.includes('application/json')
+                    ? (await res.json()).error ?? ''
+                    : await res.text();
+            } catch (_) { /* ignore body read errors */ }
+            throw new Error(`HTTP ${res.status}: ${res.statusText}${serverMsg ? ' – ' + serverMsg : ''}`);
+        }
+
+        const updated = await res.json();
+        console.log('[updateNachaSettings] Success:', updated);
+        showToast('Success', 'NACHA settings updated successfully');
+
+        // Refresh list
+        await fetchNachaSettings();
+
+        // Close modal
+        const modalEl = document.getElementById('editNachaSettingsModal');
+        if (modalEl) bootstrap.Modal.getInstance(modalEl)?.hide();
+
+        return updated;
+    } catch (err) {
+        console.error('[updateNachaSettings] Error:', err);
+        showToast('Error', 'Failed to update NACHA settings: ' + err.message, true);
+        throw err;
+    } finally {
+        hideLoading();
+    }
+}
+
+// Delete NACHA settings
+async function deleteNachaSettings(settingsId) {
+    if (!confirmDialog('Are you sure you want to delete these NACHA settings? This action cannot be undone.')) {
+        return;
+    }
+
+    try {
+        console.log('[deleteNachaSettings] Deleting NACHA settings…', settingsId);
+        showLoading();
+
+        const res = await fetch(`${API_BASE_URL}/api/nacha-settings/${settingsId}`, {
+            method: 'DELETE',
+            credentials: 'include'
+        });
+
+        if (!res.ok) {
+            let serverMsg = '';
+            try {
+                const ctype = res.headers.get('content-type') || '';
+                serverMsg = ctype.includes('application/json')
+                    ? (await res.json()).error ?? ''
+                    : await res.text();
+            } catch (_) { /* ignore body read errors */ }
+            throw new Error(`HTTP ${res.status}: ${res.statusText}${serverMsg ? ' – ' + serverMsg : ''}`);
+        }
+
+        console.log('[deleteNachaSettings] Success');
+        showToast('Success', 'NACHA settings deleted successfully');
+
+        // Refresh list
+        await fetchNachaSettings();
+
+        // Close modal if open
+        const modalEl = document.getElementById('editNachaSettingsModal');
+        if (modalEl) bootstrap.Modal.getInstance(modalEl)?.hide();
+    } catch (err) {
+        console.error('[deleteNachaSettings] Error:', err);
+        showToast('Error', 'Failed to delete NACHA settings: ' + err.message, true);
+    } finally {
+        hideLoading();
+    }
+}
+
+/* ---------------------------------------------------------------------------
+ * PAYMENT BATCH CRUD OPERATIONS
  * -------------------------------------------------------------------------*/
 
 // Helper: Create payment batch via API
@@ -636,6 +1034,145 @@ async function createPaymentBatch(batchData) {
         console.error('[createPaymentBatch] Error:', err);
         showToast('Error', 'Failed to create batch: ' + err.message, true);
         throw err;
+    } finally {
+        hideLoading();
+    }
+}
+
+// Open edit batch modal
+async function openEditBatch(batchId) {
+    try {
+        console.log('[openEditBatch] Fetching batch details…', batchId);
+        showLoading();
+
+        const res = await fetch(`${API_BASE_URL}/api/payment-batches/${batchId}`, {
+            credentials: 'include'
+        });
+
+        if (!res.ok) {
+            throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+        }
+
+        const batch = await res.json();
+        console.log('[openEditBatch] Success:', batch);
+        
+        currentBatch = batch;
+
+        // Populate form fields
+        document.getElementById('editBatchId').value = batch.id;
+        document.getElementById('editBatchNumber').value = batch.batch_number || '';
+        document.getElementById('editBatchEntityId').value = batch.entity_id || '';
+        document.getElementById('editBatchFundId').value = batch.fund_id || '';
+        document.getElementById('editNachaSettingsId').value = batch.nacha_settings_id || '';
+        
+        // Format dates for input[type=date]
+        if (batch.batch_date) {
+            const batchDate = new Date(batch.batch_date);
+            document.getElementById('editBatchDate').value = batchDate.toISOString().split('T')[0];
+        }
+        
+        if (batch.effective_date) {
+            const effectiveDate = new Date(batch.effective_date);
+            document.getElementById('editEffectiveDate').value = effectiveDate.toISOString().split('T')[0];
+        }
+        
+        document.getElementById('editBatchDescription').value = batch.description || '';
+
+        // Show the modal
+        const modal = new bootstrap.Modal(document.getElementById('editBatchModal'));
+        modal.show();
+        
+        hideLoading();
+    } catch (err) {
+        hideLoading();
+        console.error('[openEditBatch] Error:', err);
+        showToast('Error', 'Failed to load batch details: ' + err.message, true);
+    }
+}
+
+// Update payment batch
+async function updatePaymentBatch(batchId, batchData) {
+    try {
+        console.log('[updatePaymentBatch] Updating batch…', batchId, batchData);
+        showLoading();
+
+        const res = await fetch(`${API_BASE_URL}/api/payment-batches/${batchId}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify(batchData)
+        });
+
+        if (!res.ok) {
+            let serverMsg = '';
+            try {
+                const ctype = res.headers.get('content-type') || '';
+                serverMsg = ctype.includes('application/json')
+                    ? (await res.json()).error ?? ''
+                    : await res.text();
+            } catch (_) { /* ignore body read errors */ }
+            throw new Error(`HTTP ${res.status}: ${res.statusText}${serverMsg ? ' – ' + serverMsg : ''}`);
+        }
+
+        const updated = await res.json();
+        console.log('[updatePaymentBatch] Success:', updated);
+        showToast('Success', 'Payment batch updated successfully');
+
+        // Refresh list
+        await fetchBatches();
+
+        // Close modal
+        const modalEl = document.getElementById('editBatchModal');
+        if (modalEl) bootstrap.Modal.getInstance(modalEl)?.hide();
+
+        return updated;
+    } catch (err) {
+        console.error('[updatePaymentBatch] Error:', err);
+        showToast('Error', 'Failed to update batch: ' + err.message, true);
+        throw err;
+    } finally {
+        hideLoading();
+    }
+}
+
+// Delete payment batch
+async function deletePaymentBatch(batchId) {
+    if (!confirmDialog('Are you sure you want to delete this payment batch? This action cannot be undone.')) {
+        return;
+    }
+
+    try {
+        console.log('[deletePaymentBatch] Deleting batch…', batchId);
+        showLoading();
+
+        const res = await fetch(`${API_BASE_URL}/api/payment-batches/${batchId}`, {
+            method: 'DELETE',
+            credentials: 'include'
+        });
+
+        if (!res.ok) {
+            let serverMsg = '';
+            try {
+                const ctype = res.headers.get('content-type') || '';
+                serverMsg = ctype.includes('application/json')
+                    ? (await res.json()).error ?? ''
+                    : await res.text();
+            } catch (_) { /* ignore body read errors */ }
+            throw new Error(`HTTP ${res.status}: ${res.statusText}${serverMsg ? ' – ' + serverMsg : ''}`);
+        }
+
+        console.log('[deletePaymentBatch] Success');
+        showToast('Success', 'Payment batch deleted successfully');
+
+        // Refresh list
+        await fetchBatches();
+
+        // Close modal if open
+        const modalEl = document.getElementById('editBatchModal');
+        if (modalEl) bootstrap.Modal.getInstance(modalEl)?.hide();
+    } catch (err) {
+        console.error('[deletePaymentBatch] Error:', err);
+        showToast('Error', 'Failed to delete batch: ' + err.message, true);
     } finally {
         hideLoading();
     }
@@ -729,6 +1266,246 @@ document.addEventListener('DOMContentLoaded', async function() {
                 }
             });
             console.log('✅ Create-batch button listener added');
+        }
+
+        // Vendor form submission handlers
+        const createVendorForm = document.getElementById('createVendorForm');
+        if (createVendorForm) {
+            createVendorForm.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                
+                const entityId = document.getElementById('entityId').value;
+                const vendorCode = document.getElementById('vendorCode').value;
+                const name = document.getElementById('vendorName').value;
+                const contactName = document.getElementById('contactName').value;
+                const email = document.getElementById('vendorEmail').value;
+                const phone = document.getElementById('vendorPhone').value;
+                const status = document.getElementById('vendorStatus').value;
+                const notes = document.getElementById('vendorNotes').value;
+                
+                // Validation
+                if (!entityId) return showToast('Validation', 'Please select an entity', true);
+                if (!vendorCode) return showToast('Validation', 'Please enter a vendor code', true);
+                if (!name) return showToast('Validation', 'Please enter a vendor name', true);
+                
+                const vendorData = {
+                    entity_id: entityId,
+                    vendor_code: vendorCode,
+                    name,
+                    contact_name: contactName,
+                    email,
+                    phone,
+                    status,
+                    notes
+                };
+                
+                try {
+                    await createVendor(vendorData);
+                } catch (_) {
+                    /* error toast already shown */
+                }
+            });
+            console.log('✅ Create-vendor form submission handler added');
+        }
+        
+        const editVendorForm = document.getElementById('editVendorForm');
+        if (editVendorForm) {
+            editVendorForm.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                
+                const vendorId = document.getElementById('editVendorId').value;
+                const entityId = document.getElementById('editEntityId').value;
+                const vendorCode = document.getElementById('editVendorCode').value;
+                const name = document.getElementById('editVendorName').value;
+                const contactName = document.getElementById('editContactName').value;
+                const email = document.getElementById('editVendorEmail').value;
+                const phone = document.getElementById('editVendorPhone').value;
+                const status = document.getElementById('editVendorStatus').value;
+                const notes = document.getElementById('editVendorNotes').value;
+                
+                // Validation
+                if (!vendorId) return showToast('Validation', 'Vendor ID is missing', true);
+                if (!entityId) return showToast('Validation', 'Please select an entity', true);
+                if (!vendorCode) return showToast('Validation', 'Please enter a vendor code', true);
+                if (!name) return showToast('Validation', 'Please enter a vendor name', true);
+                
+                const vendorData = {
+                    entity_id: entityId,
+                    vendor_code: vendorCode,
+                    name,
+                    contact_name: contactName,
+                    email,
+                    phone,
+                    status,
+                    notes
+                };
+                
+                try {
+                    await updateVendor(vendorId, vendorData);
+                } catch (_) {
+                    /* error toast already shown */
+                }
+            });
+            console.log('✅ Edit-vendor form submission handler added');
+        }
+        
+        // Delete vendor button handler
+        const deleteVendorBtn = document.getElementById('deleteVendorBtn');
+        if (deleteVendorBtn) {
+            deleteVendorBtn.addEventListener('click', () => {
+                const vendorId = document.getElementById('editVendorId').value;
+                if (vendorId) {
+                    deleteVendor(vendorId);
+                }
+            });
+            console.log('✅ Delete-vendor button handler added');
+        }
+        
+        // NACHA Settings form submission handlers
+        const createNachaSettingsForm = document.getElementById('createNachaSettingsForm');
+        if (createNachaSettingsForm) {
+            createNachaSettingsForm.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                
+                const entityId = document.getElementById('settingsEntityId').value;
+                const settlementAccountId = document.getElementById('settlementAccountId').value;
+                const companyName = document.getElementById('companyName').value;
+                const companyId = document.getElementById('companyId').value;
+                const originatingDfiId = document.getElementById('originatingDfiId').value;
+                const companyEntryDescription = document.getElementById('companyEntryDescription').value;
+                const isProduction = document.getElementById('isProduction').checked;
+                
+                // Validation
+                if (!entityId) return showToast('Validation', 'Please select an entity', true);
+                if (!companyName) return showToast('Validation', 'Please enter a company name', true);
+                if (!companyId) return showToast('Validation', 'Please enter a company ID', true);
+                if (!originatingDfiId) return showToast('Validation', 'Please enter an originating DFI ID', true);
+                
+                const settingsData = {
+                    entity_id: entityId,
+                    settlement_account_id: settlementAccountId,
+                    company_name: companyName,
+                    company_id: companyId,
+                    originating_dfi_id: originatingDfiId,
+                    company_entry_description: companyEntryDescription || 'PAYMENT',
+                    is_production: isProduction
+                };
+                
+                try {
+                    await createNachaSettings(settingsData);
+                } catch (_) {
+                    /* error toast already shown */
+                }
+            });
+            console.log('✅ Create-NACHA-settings form submission handler added');
+        }
+        
+        const editNachaSettingsForm = document.getElementById('editNachaSettingsForm');
+        if (editNachaSettingsForm) {
+            editNachaSettingsForm.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                
+                const settingsId = document.getElementById('editNachaSettingsId').value;
+                const entityId = document.getElementById('editSettingsEntityId').value;
+                const settlementAccountId = document.getElementById('editSettlementAccountId').value;
+                const companyName = document.getElementById('editCompanyName').value;
+                const companyId = document.getElementById('editCompanyId').value;
+                const originatingDfiId = document.getElementById('editOriginatingDfiId').value;
+                const companyEntryDescription = document.getElementById('editCompanyEntryDescription').value;
+                const isProduction = document.getElementById('editIsProduction').checked;
+                
+                // Validation
+                if (!settingsId) return showToast('Validation', 'Settings ID is missing', true);
+                if (!entityId) return showToast('Validation', 'Please select an entity', true);
+                if (!companyName) return showToast('Validation', 'Please enter a company name', true);
+                if (!companyId) return showToast('Validation', 'Please enter a company ID', true);
+                if (!originatingDfiId) return showToast('Validation', 'Please enter an originating DFI ID', true);
+                
+                const settingsData = {
+                    entity_id: entityId,
+                    settlement_account_id: settlementAccountId,
+                    company_name: companyName,
+                    company_id: companyId,
+                    originating_dfi_id: originatingDfiId,
+                    company_entry_description: companyEntryDescription || 'PAYMENT',
+                    is_production: isProduction
+                };
+                
+                try {
+                    await updateNachaSettings(settingsId, settingsData);
+                } catch (_) {
+                    /* error toast already shown */
+                }
+            });
+            console.log('✅ Edit-NACHA-settings form submission handler added');
+        }
+        
+        // Delete NACHA settings button handler
+        const deleteNachaSettingsBtn = document.getElementById('deleteNachaSettingsBtn');
+        if (deleteNachaSettingsBtn) {
+            deleteNachaSettingsBtn.addEventListener('click', () => {
+                const settingsId = document.getElementById('editNachaSettingsId').value;
+                if (settingsId) {
+                    deleteNachaSettings(settingsId);
+                }
+            });
+            console.log('✅ Delete-NACHA-settings button handler added');
+        }
+        
+        // Edit Batch form submission handler
+        const editBatchForm = document.getElementById('editBatchForm');
+        if (editBatchForm) {
+            editBatchForm.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                
+                const batchId = document.getElementById('editBatchId').value;
+                const batchNumber = document.getElementById('editBatchNumber').value;
+                const entityId = document.getElementById('editBatchEntityId').value;
+                const fundId = document.getElementById('editBatchFundId').value;
+                const nachaSettingsId = document.getElementById('editNachaSettingsId').value;
+                const batchDate = document.getElementById('editBatchDate').value;
+                const effectiveDate = document.getElementById('editEffectiveDate').value;
+                const description = document.getElementById('editBatchDescription').value;
+                
+                // Validation
+                if (!batchId) return showToast('Validation', 'Batch ID is missing', true);
+                if (!batchNumber) return showToast('Validation', 'Please enter a batch number', true);
+                if (!entityId) return showToast('Validation', 'Please select an entity', true);
+                if (!nachaSettingsId) return showToast('Validation', 'Please select NACHA settings', true);
+                if (!batchDate) return showToast('Validation', 'Please enter a batch date', true);
+                if (!effectiveDate) return showToast('Validation', 'Please enter an effective date', true);
+                
+                const batchData = {
+                    entity_id: entityId,
+                    fund_id: fundId || null,
+                    nacha_settings_id: nachaSettingsId,
+                    batch_name: batchNumber, // API expects batch_name but stores as batch_number
+                    batch_date: batchDate,
+                    effective_date: effectiveDate,
+                    description,
+                    status: currentBatch.status,
+                    total_amount: currentBatch.total_amount
+                };
+                
+                try {
+                    await updatePaymentBatch(batchId, batchData);
+                } catch (_) {
+                    /* error toast already shown */
+                }
+            });
+            console.log('✅ Edit-batch form submission handler added');
+        }
+        
+        // Delete batch button handler
+        const deleteBatchBtn = document.getElementById('deleteBatchBtn');
+        if (deleteBatchBtn) {
+            deleteBatchBtn.addEventListener('click', () => {
+                const batchId = document.getElementById('editBatchId').value;
+                if (batchId) {
+                    deletePaymentBatch(batchId);
+                }
+            });
+            console.log('✅ Delete-batch button handler added');
         }
 
         console.log('✅ Vendor Payments page initialized successfully');

--- a/vendor-payments.html
+++ b/vendor-payments.html
@@ -266,5 +266,280 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/js/bootstrap.bundle.min.js"></script>
     <script src="src/js/vendor-payments.js"></script>
+
+    <!-- ===================================================================== -->
+    <!--  VENDOR CRUD MODALS                                                   -->
+    <!-- ===================================================================== -->
+
+    <!-- Create Vendor -->
+    <div class="modal fade" id="createVendorModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">New Vendor</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <form id="createVendorForm">
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label for="entityId" class="form-label">Entity*</label>
+                            <select id="entityId" class="form-select" required>
+                                <option value="">-- Select Entity --</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="vendorCode" class="form-label">Vendor Code*</label>
+                            <input type="text" id="vendorCode" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="vendorName" class="form-label">Vendor Name*</label>
+                            <input type="text" id="vendorName" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="contactName" class="form-label">Contact Name</label>
+                            <input type="text" id="contactName" class="form-control" />
+                        </div>
+                        <div class="mb-3">
+                            <label for="vendorEmail" class="form-label">Email</label>
+                            <input type="email" id="vendorEmail" class="form-control" />
+                        </div>
+                        <div class="mb-3">
+                            <label for="vendorPhone" class="form-label">Phone</label>
+                            <input type="text" id="vendorPhone" class="form-control" />
+                        </div>
+                        <div class="mb-3">
+                            <label for="vendorStatus" class="form-label">Status</label>
+                            <select id="vendorStatus" class="form-select">
+                                <option value="active">Active</option>
+                                <option value="inactive">Inactive</option>
+                                <option value="suspended">Suspended</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="vendorNotes" class="form-label">Notes</label>
+                            <textarea id="vendorNotes" class="form-control" rows="3"></textarea>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary" id="saveVendorBtn">Save Vendor</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Edit Vendor -->
+    <div class="modal fade" id="editVendorModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Edit Vendor</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <form id="editVendorForm">
+                    <div class="modal-body">
+                        <input type="hidden" id="editVendorId" />
+                        <div class="mb-3">
+                            <label for="editEntityId" class="form-label">Entity*</label>
+                            <select id="editEntityId" class="form-select" required></select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editVendorCode" class="form-label">Vendor Code*</label>
+                            <input type="text" id="editVendorCode" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="editVendorName" class="form-label">Vendor Name*</label>
+                            <input type="text" id="editVendorName" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="editContactName" class="form-label">Contact Name</label>
+                            <input type="text" id="editContactName" class="form-control" />
+                        </div>
+                        <div class="mb-3">
+                            <label for="editVendorEmail" class="form-label">Email</label>
+                            <input type="email" id="editVendorEmail" class="form-control" />
+                        </div>
+                        <div class="mb-3">
+                            <label for="editVendorPhone" class="form-label">Phone</label>
+                            <input type="text" id="editVendorPhone" class="form-control" />
+                        </div>
+                        <div class="mb-3">
+                            <label for="editVendorStatus" class="form-label">Status</label>
+                            <select id="editVendorStatus" class="form-select">
+                                <option value="active">Active</option>
+                                <option value="inactive">Inactive</option>
+                                <option value="suspended">Suspended</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editVendorNotes" class="form-label">Notes</label>
+                            <textarea id="editVendorNotes" class="form-control" rows="3"></textarea>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-danger me-auto" id="deleteVendorBtn">Delete</button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary" id="updateVendorBtn">Update Vendor</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- ===================================================================== -->
+    <!--  NACHA SETTINGS CRUD MODALS                                           -->
+    <!-- ===================================================================== -->
+
+    <!-- Create NACHA Settings -->
+    <div class="modal fade" id="createNachaSettingsModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">New NACHA Configuration</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <form id="createNachaSettingsForm">
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label for="settingsEntityId" class="form-label">Entity*</label>
+                            <select id="settingsEntityId" class="form-select" required></select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="settlementAccountId" class="form-label">Settlement Account*</label>
+                            <select id="settlementAccountId" class="form-select" required></select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="companyName" class="form-label">Company Name* (≤16 chars)</label>
+                            <input type="text" id="companyName" class="form-control" maxlength="16" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="companyId" class="form-label">Company ID*</label>
+                            <input type="text" id="companyId" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="originatingDfiId" class="form-label">Originating DFI ID*</label>
+                            <input type="text" id="originatingDfiId" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="companyEntryDescription" class="form-label">Entry Description</label>
+                            <input type="text" id="companyEntryDescription" class="form-control" />
+                        </div>
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" type="checkbox" id="isProduction" />
+                            <label class="form-check-label" for="isProduction">Production Mode</label>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary" id="saveNachaSettingsBtn">Save Settings</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Edit NACHA Settings -->
+    <div class="modal fade" id="editNachaSettingsModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Edit NACHA Configuration</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <form id="editNachaSettingsForm">
+                    <div class="modal-body">
+                        <input type="hidden" id="editNachaSettingsId" />
+                        <div class="mb-3">
+                            <label for="editSettingsEntityId" class="form-label">Entity*</label>
+                            <select id="editSettingsEntityId" class="form-select" required></select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editSettlementAccountId" class="form-label">Settlement Account*</label>
+                            <select id="editSettlementAccountId" class="form-select" required></select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editCompanyName" class="form-label">Company Name* (≤16 chars)</label>
+                            <input type="text" id="editCompanyName" class="form-control" maxlength="16" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="editCompanyId" class="form-label">Company ID*</label>
+                            <input type="text" id="editCompanyId" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="editOriginatingDfiId" class="form-label">Originating DFI ID*</label>
+                            <input type="text" id="editOriginatingDfiId" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="editCompanyEntryDescription" class="form-label">Entry Description</label>
+                            <input type="text" id="editCompanyEntryDescription" class="form-control" />
+                        </div>
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" type="checkbox" id="editIsProduction" />
+                            <label class="form-check-label" for="editIsProduction">Production Mode</label>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-danger me-auto" id="deleteNachaSettingsBtn">Delete</button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary" id="updateNachaSettingsBtn">Update Settings</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- ===================================================================== -->
+    <!--  EDIT PAYMENT BATCH MODAL                                             -->
+    <!-- ===================================================================== -->
+
+    <div class="modal fade" id="editBatchModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Edit Payment Batch</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <form id="editBatchForm">
+                    <div class="modal-body">
+                        <input type="hidden" id="editBatchId" />
+                        <div class="mb-3">
+                            <label for="editBatchNumber" class="form-label">Batch Number*</label>
+                            <input type="text" id="editBatchNumber" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="editBatchEntityId" class="form-label">Entity*</label>
+                            <select id="editBatchEntityId" class="form-select" required></select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editBatchFundId" class="form-label">Fund</label>
+                            <select id="editBatchFundId" class="form-select"></select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editNachaSettingsId" class="form-label">NACHA Settings*</label>
+                            <select id="editNachaSettingsId" class="form-select" required></select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="editBatchDate" class="form-label">Batch Date*</label>
+                            <input type="date" id="editBatchDate" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="editEffectiveDate" class="form-label">Effective Date*</label>
+                            <input type="date" id="editEffectiveDate" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="editBatchDescription" class="form-label">Description</label>
+                            <input type="text" id="editBatchDescription" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-danger me-auto" id="deleteBatchBtn">Delete</button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary" id="updateBatchBtn">Update Batch</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
This PR wires the Fund Reports "Generate Report" button and implements client-side renderers:\n\n- Fund Balance summary (code/name, entity, type, current balance)\n- Fund Activity (journal lines for selected fund and date range; totals)\n- Fund Statement (aggregates by account type: Revenue vs Expense; Net Change)\n- Funds Comparison (current context funds with % of total)\n\nNotes:\n- Uses existing app state, formatters, and fetchData; no server changes.\n- Sets sensible default date range (Jan 1 of current year to today).\n- Guardrails: warns if a fund isn\'t selected where required.\n\nValidated locally on macOS demo.\n\nDroid-assisted PR.