### PR TITLE
docs: add handoff.md (session context pack)

### DIFF
--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,94 @@
+# Handoff Context Pack — Mr. MoneyBags v1.x
+
+Date: 2025-08-14 14:00:41
+
+## Repository
+- URL: https://github.com/tpfbill/mr-moneybags-v1.x.git
+- Default branch: main
+- Local path: /Users/william/factory/mr-moneybags
+
+## Snapshot (safe restore point)
+- Branch: snapshot/macos-demo-20250814-103332
+- Tag: macos-demo-snapshot-20250814-103332
+- Restore commands:
+  - `git fetch --all --tags`
+  - `git checkout tags/macos-demo-snapshot-20250814-103332`
+
+## Open Pull Requests
+1) feat(fund-reports): wire Generate Report + basic report renderers  
+   - Branch: droid/fund-reports-generate  
+   - PR: https://github.com/tpfbill/mr-moneybags-v1.x/pull/2  
+   - Summary:  
+     - “Generate Report” on Fund Reports now works.  
+     - Implemented:  
+       - Fund Balance summary  
+       - Fund Activity (lines + totals)  
+       - Fund Statement (Revenue/Expense aggregation + Net change)  
+       - Funds Comparison (% of total)  
+     - Uses existing formatters/state/api; sets sensible default dates; warns if no fund selected.
+
+2) fix(ui): restore Entity column in Chart of Accounts  
+   - Branch: droid/restore-coa-entity-column  
+   - PR: https://github.com/tpfbill/mr-moneybags-v1.x/pull/3  
+   - Summary:  
+     - Restored Entity column in the Chart of Accounts header and rows (between Type and Balance).  
+     - Fixed empty-state colspan to match the new column count (7).
+
+## Recent key file changes (high level)
+- **src/js/app-main.js**  
+  - Fund Reports wiring added:  
+    - `initializeFundReportsActions()`  
+    - `generateFundReports()`  
+    - `getActiveFundReportTabId()`  
+    - `renderFundBalanceReport()`  
+    - `loadFundActivityLines()`  
+    - `renderFundActivityReport()`  
+    - `renderFundStatementReport()`  
+    - `renderFundsComparisonReport()`  
+  - Hooks into `showPage('fund-reports')` to bind actions on first entry.
+
+- **index.html**  
+  - Restored “Entity” column in the Chart of Accounts table header.  
+  - (Earlier in the session: multiple modals aligned with app-modals.js expectations.)
+
+- **src/js/app-ui.js**  
+  - `updateChartOfAccountsTable()` now renders the Entity column and fixes the empty-state colspan.
+
+- **vendor payments & check printing (context)**  
+  - Vendor payments CRUD implemented on its own feature branch previously.  
+  - Check printing page fixes (form wrapper; toast shim) were explored; authentication/database checks noted.
+
+## Environment & running
+- Local demo focus (macOS); Ubuntu deployment not required now.  
+- Typical setup:  
+  - API server on port 3000, web client on 8080.  
+  - Ensure you’re logged in (session cookies) before testing pages to avoid 401/redirect noise.
+
+## What to test first
+- **Chart of Accounts**  
+  - Confirm Entity column appears and is populated.  
+  - Empty state shows the correct colspan (7).  
+- **Fund Reports**  
+  - Select a fund, pick/accept date defaults, click Generate.  
+  - Verify each tab renders: Balance, Activity (lines + totals), Statement (Rev/Exp + Net), Comparison (% of total).  
+- **Quick regression sweep**  
+  - Dashboard loads, funds and journal entries tables render; no console errors.
+
+## Quick commands
+- Update and list open PRs  
+  - `git fetch --all --tags`  
+  - `gh pr list -s open`
+- Switch branches  
+  - `git checkout droid/fund-reports-generate`  
+  - `git checkout droid/restore-coa-entity-column`
+- Restore exact snapshot  
+  - `git checkout tags/macos-demo-snapshot-20250814-103332`
+
+## Notes & next steps (optional)
+- Consider reviewing and merging PR #2 and #3 after local validation.  
+- If anything regresses, use the snapshot tag to restore instantly.  
+- Deferred work (if/when needed): unified database complete-schema.sql and Ubuntu automation.
+
+---
+
+This handoff is intended to give a new session immediate situational awareness. Paste the “Quick commands” and the PR links into the next session if needed, and keep the browser session authenticated while testing.


### PR DESCRIPTION
Adds a comprehensive handoff.md to the repo root with:\n\n- Repository details and safe restore snapshot (branch + tag)\n- Open PR summaries with links (#2 Fund Reports, #3 COA Entity column)\n- Recent key file changes (high-level)\n- Environment/run notes for macOS demo\n- Testing checklist and quick commands\n\nThis enables a new session to ramp instantly with maximum context.\n\nDroid-assisted PR.