### PR TITLE
fix(users): normalize status + case-insensitive auth (Droid-assisted)

### DIFF
--- a/index.html
+++ b/index.html
@@ -868,8 +868,8 @@
                                 <select id="user-status"
                                         name="user-status"
                                         class="form-input">
-                                    <option value="Active">Active</option>
-                                    <option value="Inactive">Inactive</option>
+                                    <option value="active">Active</option>
+                                    <option value="inactive">Inactive</option>
                                 </select>
                             </div>
                         </div>

--- a/src/js/app-modals.js
+++ b/src/js/app-modals.js
@@ -1096,7 +1096,8 @@ export async function openUserModal(id) {
             form.elements['user-email'].value = user.email || '';
             form.elements['user-username'].value = user.username || '';
             form.elements['user-role'].value = user.role || 'user';
-            form.elements['user-status'].value = user.status || 'Active';
+            // Always normalise status to lowercase for consistency with backend
+            form.elements['user-status'].value = (user.status || 'active').toLowerCase();
         } catch (error) {
             console.error('Error fetching user data:', error);
             showToast('Error loading user data', 'error');
@@ -1138,7 +1139,8 @@ export async function saveUser(event) {
         email      : form.elements['user-email'].value,
         username   : form.elements['user-username'].value,
         role       : form.elements['user-role'].value,
-        status     : form.elements['user-status'].value
+        // Normalise status to lowercase before sending to API
+        status     : (form.elements['user-status'].value || 'active').toLowerCase()
     };
     
     // Add password if provided

--- a/src/js/app-ui.js
+++ b/src/js/app-ui.js
@@ -757,13 +757,17 @@ export function updateUsersTable() {
     sortedUsers.forEach(user => {
         // Handle both name formats (name or first_name + last_name)
         const displayName = user.name || `${user.first_name} ${user.last_name}`;
+        // Normalise status for consistent class naming & human-friendly label
+        const statusRaw   = (user.status || 'active');
+        const statusCls   = statusRaw.toLowerCase();
+        const statusLabel = statusRaw.charAt(0).toUpperCase() + statusRaw.slice(1);
         
         const row = document.createElement('tr');
         row.innerHTML = `
             <td>${displayName}</td>
             <td>${user.email}</td>
             <td>${user.role}</td>
-            <td><span class="status status-${user.status?.toLowerCase() || 'active'}">${user.status || 'Active'}</span></td>
+            <td><span class="status status-${statusCls}">${statusLabel}</span></td>
             <td>
                 <button class="action-button btn-edit-user" data-id="${user.id}">Edit</button>
             </td>

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -80,7 +80,7 @@ function requireRole(roles) {
         const user = await getUserById(req.session.userId);
         
         // Check if user exists and is active
-        if (!user || user.status !== 'active') {
+        if (!user || (user.status || '').toLowerCase() !== 'active') {
             req.session.destroy();
             
             // Handle API requests
@@ -132,7 +132,7 @@ async function getCurrentUser(req, res, next) {
         const user = await getUserById(req.session.userId);
         
         // If user exists and is active, attach to request
-        if (user && user.status === 'active') {
+        if (user && (user.status || '').toLowerCase() === 'active') {
             req.user = user;
         } else {
             // Clear invalid session
@@ -163,7 +163,7 @@ function redirectIfAuthenticated(redirectTo = '/index.html') {
             const user = await getUserById(req.session.userId);
             
             // If user exists and is active, redirect
-            if (user && user.status === 'active') {
+            if (user && (user.status || '').toLowerCase() === 'active') {
                 return res.redirect(redirectTo);
             } else {
                 // Clear invalid session

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -35,7 +35,7 @@ router.post('/login', asyncHandler(async (req, res) => {
     const user = userResult.rows[0];
     
     // Check if user is active
-    if (user.status !== 'active') {
+    if ((user.status || '').toLowerCase() !== 'active') {
         return res.status(401).json({ 
             error: 'Account is inactive. Please contact an administrator.' 
         });

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -98,12 +98,15 @@ router.post('/', asyncHandler(async (req, res) => {
     // Hash the password
     const saltRounds = 10;
     const password_hash = await bcrypt.hash(password, saltRounds);
+
+    // Normalise status to lowercase to avoid case-sensitivity issues
+    const normStatus = (status || 'active').toLowerCase();
     
     const { rows } = await pool.query(
         `INSERT INTO users (
             username, password_hash, email, first_name, last_name, role, status
         ) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *`,
-        [username, password_hash, email, first_name, last_name, role || 'user', status || 'active']
+        [username, password_hash, email, first_name, last_name, role || 'user', normStatus]
     );
     
     // Remove password hash from response
@@ -191,7 +194,8 @@ router.put('/:id', asyncHandler(async (req, res) => {
     
     if (status !== undefined) {
         updates.push(`status = $${paramIndex++}`);
-        params.push(status);
+        // Ensure status stored in lowercase
+        params.push(String(status).toLowerCase());
     }
     
     // Add updated_at timestamp


### PR DESCRIPTION
This PR fixes a regression where newly-created users marked "Active" were treated as inactive at login, and existing users showed a blank Status in the edit modal.\n\nChanges\n- Frontend\n  - User modal: status select now uses lowercase values (active/inactive).\n  - User modal save/edit: normalize status to lowercase.\n  - Users table: consistent status class; capitalized display label.\n- API\n  - users routes: store status in lowercase on create/update.\n  - auth + middleware: treat status case-insensitively when checking activity.\n\nResult\n- Kevin (created as "Active") can log in immediately.\n- Editing existing users shows Status correctly.\n- Future user saves store canonical lowercase status.\n\nManual test plan\n1. Restart backend: npm run start\n2. Login with an admin account, navigate to Settings → Users.\n3. Edit any existing user: Status shows Active/Inactive correctly. Save.\n4. Log out and log in as Kevin (or any newly created Active user).\n\nNotes\n- No schema changes; only normalization + tolerant checks.\n- Safe for existing data; will self-correct on next update.\n\nDroid-assisted PR.