### PR TITLE
chore(db): idempotent constraints + robust DB config fallback + setup psql without PGPASSWORD when unset [Droid-assisted PR]

### DIFF
--- a/database/db-init.sql
+++ b/database/db-init.sql
@@ -565,13 +565,29 @@ CREATE TABLE IF NOT EXISTS custom_report_definitions (
 -- =============================================================================
 
 -- Journal Entry Items constraints with updated column names
-ALTER TABLE IF EXISTS journal_entry_items 
-ADD CONSTRAINT chk_debit_credit_not_both_zero 
-CHECK (debit > 0 OR credit > 0);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'chk_debit_credit_not_both_zero'
+    ) THEN
+        ALTER TABLE journal_entry_items
+            ADD CONSTRAINT chk_debit_credit_not_both_zero
+            CHECK (debit > 0 OR credit > 0);
+    END IF;
+END $$;
 
-ALTER TABLE IF EXISTS journal_entry_items 
-ADD CONSTRAINT chk_debit_or_credit_only 
-CHECK ((debit > 0 AND credit = 0) OR (credit > 0 AND debit = 0));
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'chk_debit_or_credit_only'
+    ) THEN
+        ALTER TABLE journal_entry_items
+            ADD CONSTRAINT chk_debit_or_credit_only
+            CHECK ((debit > 0 AND credit = 0) OR (credit > 0 AND debit = 0));
+    END IF;
+END $$;
 
 -- Indexes for performance
 CREATE INDEX IF NOT EXISTS idx_journal_entries_entity_id ON journal_entries(entity_id);

--- a/database/setup-complete.js
+++ b/database/setup-complete.js
@@ -218,7 +218,9 @@ async function initializeDatabaseSchema() {
   
   try {
     const dbConfig = getDbConfig();
-    const command = `PGPASSWORD=${dbConfig.password} psql -U ${dbConfig.user} -h ${dbConfig.host} -p ${dbConfig.port} -d ${dbConfig.database} -f ${dbInitPath}`;
+    // Build command with conditional PGPASSWORD prefix
+    const pwdPrefix = dbConfig.password ? `PGPASSWORD=${dbConfig.password} ` : '';
+    const command   = `${pwdPrefix}psql -U ${dbConfig.user} -h ${dbConfig.host} -p ${dbConfig.port} -d ${dbConfig.database} -f ${dbInitPath}`;
     
     printInfo('Executing db-init.sql...');
     const output = execSync(command, { encoding: 'utf8' });

--- a/src/db/db-config.js
+++ b/src/db/db-config.js
@@ -1,28 +1,65 @@
 // db-config.js
 // Client-side configuration for database connection parameters.
 
-// Allow overriding via environment variables while keeping sensible defaults
-// so the config automatically matches the local PostgreSQL setup but can be
-// customized without editing source code.
-const DB_CONFIG = {
-    host: process.env.PGHOST || 'localhost',
-    port: Number(process.env.PGPORT) || 5432,
-    user: process.env.PGUSER || 'postgres',
-    password: process.env.PGPASSWORD || 'npfa123',
-    database: process.env.PGDATABASE || 'fund_accounting_db'
-};
-
 // Helper function to get the database configuration.
+// Implements a robust fallback chain:
+// 1. Use DATABASE_URL if available (with SSL configuration from PGSSLMODE)
+// 2. Otherwise build from individual env vars with sensible defaults
+// 3. For username, try multiple environment variables and OS username before fallback
 function getDbConfig() {
-    return DB_CONFIG;
+  // If DATABASE_URL is set, use it as a connection string
+  if (typeof process !== 'undefined' && process.env && process.env.DATABASE_URL) {
+    const config = { connectionString: process.env.DATABASE_URL };
+    
+    // Add SSL configuration if PGSSLMODE is set
+    const sslMode = process.env.PGSSLMODE;
+    if (sslMode && sslMode !== 'disable') {
+      config.ssl = { 
+        rejectUnauthorized: sslMode === 'verify-ca' || sslMode === 'verify-full' 
+      };
+    }
+    
+    return config;
+  }
+  
+  // Otherwise, build config from individual parameters
+  const host = process.env.PGHOST || 'localhost';
+  const port = Number(process.env.PGPORT) || 5432;
+  const database = process.env.PGDATABASE || 'fund_accounting_db';
+  
+  // Try multiple sources for username with fallback chain
+  let user = process.env.PGUSER || process.env.USER || process.env.LOGNAME;
+  if (!user && typeof require === 'function') {
+    try {
+      // Only try to use os module if we're in Node
+      user = require('os').userInfo().username;
+    } catch (_) {
+      // Fallback if os module not available or fails
+      user = 'postgres';
+    }
+  }
+  if (!user) user = 'postgres'; // Final fallback
+  
+  // Build the config object
+  const config = { host, port, user, database };
+  
+  // Only include password if defined
+  const password = process.env.PGPASSWORD;
+  if (password) {
+    config.password = password;
+  }
+  
+  return config;
 }
 
 // For browser environment
 if (typeof window !== 'undefined') {
-    window.getDbConfig = getDbConfig;
+  window.getDbConfig = getDbConfig;
 }
 
 // For Node.js environment
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { getDbConfig, DB_CONFIG };
+  // For Node, compute DB_CONFIG at export time
+  const DB_CONFIG = typeof process !== 'undefined' ? getDbConfig() : {};
+  module.exports = { getDbConfig, DB_CONFIG };
 }


### PR DESCRIPTION
This PR hardens database setup and configuration.

Changes:
- database/db-init.sql: wrap journal_entry_items constraint additions in DO $$ blocks to avoid transaction aborts when re-running the seed (idempotent).
- src/db/db-config.js: prefer DATABASE_URL, otherwise build from PG* env vars; fall back to OS username when PGUSER is not set; optional SSL via PGSSLMODE.
- database/setup-complete.js: omit PGPASSWORD in psql invocation when no password is provided (works with peer/local auth).

Why:
- Prevents seed failures on repeated runs.
- Eliminates reliance on hardcoded postgres user; respects local OS setup.
- Makes setup script work in environments without a DB password.

Validation:
- Re-ran db-init.sql with ON_ERROR_STOP=1 → clean.
- App connects using OS user fallback.

Droid-assisted PR.

---
**Factory Session:** https://app.factory.ai/sessions/KbMyUqqi6RvJVdXSkwWa (created by tpfbill)