### PR TITLE
Vendors: green action buttons; admin‑only visibility for Add/Edit/Delete (Droid‑assisted)

### DIFF
--- a/src/js/vendor-payments.js
+++ b/src/js/vendor-payments.js
@@ -623,7 +623,7 @@ function renderVendorsTable() {
         /* actions buttons */
         const actions = isAdminUser ? `
             <div class="btn-group btn-group-sm">
-                <button class="btn btn-success btn-edit-vendor" data-id="${vendor.id}" title="Edit Vendor">
+                <button class="btn btn-success btn-edit-vendor me-1" data-id="${vendor.id}" title="Edit Vendor">
                     <i class="fas fa-edit me-1"></i> Edit
                 </button>
                 <button class="btn btn-success btn-delete-vendor" data-id="${vendor.id}" title="Delete Vendor">

--- a/src/js/vendor-payments.js
+++ b/src/js/vendor-payments.js
@@ -624,10 +624,10 @@ function renderVendorsTable() {
         const actions = isAdminUser ? `
             <div class="btn-group btn-group-sm">
                 <button class="btn btn-success btn-edit-vendor" data-id="${vendor.id}" title="Edit Vendor">
-                    <i class="fas fa-edit"></i>
+                    <i class="fas fa-edit me-1"></i> Edit
                 </button>
                 <button class="btn btn-success btn-delete-vendor" data-id="${vendor.id}" title="Delete Vendor">
-                    <i class="fas fa-trash"></i>
+                    <i class="fas fa-trash me-1"></i> Delete
                 </button>
             </div>
         ` : '';

--- a/vendor-payments.html
+++ b/vendor-payments.html
@@ -107,7 +107,7 @@
             <div class="tab-pane fade" id="vendors" role="tabpanel">
                 <div class="section-header d-flex justify-content-between align-items-center">
                     <h2>Vendors <span id="vendorsCountBadge" class="badge bg-secondary ms-2">0</span></h2>
-                    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createVendorModal">
+                    <button id="newVendorBtn" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#createVendorModal">
                         <i class="fas fa-plus"></i> New Vendor
                     </button>
                 </div>


### PR DESCRIPTION
UI/UX and RBAC refinements for Vendors:

- Make Edit and Delete row actions green (Bootstrap `btn-success`) to match app style
- Make Add (New Vendor) button green as well
- Hide all three actions (Add/Edit/Delete) for non‑admin users (client‑side RBAC)
  - Determine role via GET /api/auth/user; set `isAdminUser` flag
  - Toggle Add button (#newVendorBtn) and modal Delete button (#deleteVendorBtn)
  - Render row actions only when `isAdminUser`

Files
- vendor-payments.html: New Vendor button -> green and got `id="newVendorBtn"`
- src/js/vendor-payments.js: role fetch + UI toggles; renderVendorsTable() uses green buttons and admin‑only actions

Notes
- Server already exposes /api/auth/user with `user.role`
- This is client-side visibility; server should still enforce permissions on vendor routes as needed

Droid-assisted PR.

---
**Factory Session:** https://app.factory.ai/sessions/I6DIrEmYycUmCbIcbLvg (created by tpfbill)