### PR TITLE
Funds UI: keep fund code on a single line and size column to 8ch (Droid‑assisted)

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
                 <thead>
                     <tr>
                         <th>Number</th>
-                        <th>Code</th>
+                        <th class="fund-code">Code</th>
                         <th>Entity&nbsp;Code</th>
                         <th>Entity&nbsp;Name</th>
                         <th>Name</th>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -575,3 +575,17 @@ textarea.form-input:focus {
 #fund-distribution-chart {
     max-width: 500px;
 }
+
+/* ------------------------------------------------------------------
+   Funds table – Code column styling
+   ------------------------------------------------------------------ */
+#funds-table th.fund-code,
+#funds-table td.fund-code {
+    /* Prevent wrapping so the code stays on a single line */
+    white-space: nowrap;
+
+    /* Fixed width for up-to-8-character codes (using monospace-width unit) */
+    width: 8ch;
+    min-width: 8ch;
+    max-width: 8ch;
+}

--- a/src/js/app-ui.js
+++ b/src/js/app-ui.js
@@ -468,7 +468,7 @@ export function updateFundsTable() {
         const row = document.createElement('tr');
         row.innerHTML = `
             <td>${fund.fund_number || '—'}</td>
-            <td>${fund.fund_code}</td>
+            <td class="fund-code">${fund.fund_code}</td>
             <td>${fund.entity_code || '—'}</td>
             <td>${fund.entity_name || '—'}</td>
             <td>${fund.fund_name}</td>


### PR DESCRIPTION
Change
- Funds table: mark Code column header and cells with .fund-code and style to not wrap; fixed width 8ch to fit up to 8 characters

Why
- Fund codes are max 8 chars and should display on one line for readability and column alignment

Scope
- Frontend-only: index.html (header class), src/js/app-ui.js (cell class), src/css/styles.css (column CSS)

Validation
- Load Funds tab; confirm Code column stays single-line and fits 8-char width

Notes
- Droid-assisted PR

---
**Factory Session:** https://app.factory.ai/sessions/fuu474Ia74J4HxiyEwmH (created by tpfbill)