### PR TITLE
feat(db): add bank_accounts beginning_balance (+date) and align schema files

### DIFF
--- a/database/master-schema.sql
+++ b/database/master-schema.sql
@@ -203,10 +203,11 @@ CREATE TABLE IF NOT EXISTS custom_report_definitions (
 );
 COMMENT ON TABLE custom_report_definitions IS 'Custom report definitions created by users';
 
--- Bank Accounts table
 CREATE TABLE IF NOT EXISTS bank_accounts (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     entity_id UUID REFERENCES entities(id) ON DELETE SET NULL,
+    gl_account_id UUID REFERENCES accounts(id) ON DELETE SET NULL,
+    cash_account_id UUID REFERENCES accounts(id) ON DELETE SET NULL,
     bank_name VARCHAR(255) NOT NULL,
     account_name VARCHAR(255) NOT NULL,
     account_number VARCHAR(100),
@@ -214,9 +215,13 @@ CREATE TABLE IF NOT EXISTS bank_accounts (
     type VARCHAR(50) DEFAULT 'Checking',
     status VARCHAR(20) DEFAULT 'Active',
     balance DECIMAL(15,2) DEFAULT 0.00,
+    beginning_balance DECIMAL(15,2) DEFAULT 0.00,
+    beginning_balance_date DATE,
     connection_method VARCHAR(50) DEFAULT 'Manual',
     description TEXT,
     last_reconciliation_date DATE,
+    last_reconciliation_id UUID,
+    reconciled_balance DECIMAL(15,2) DEFAULT 0.00,
     last_sync TIMESTAMPTZ,
     created_at TIMESTAMPTZ DEFAULT NOW(),
     updated_at TIMESTAMPTZ DEFAULT NOW(),

--- a/database/migrations/2025-09-29-01_add-bank-accounts-beginning-balance.sql
+++ b/database/migrations/2025-09-29-01_add-bank-accounts-beginning-balance.sql
@@ -1,0 +1,48 @@
+-- database/migrations/2025-09-29-01_add-bank-accounts-beginning-balance.sql
+-- Purpose: Align bank_accounts schema with runtime expectations and add
+--          beginning balance support with safe, idempotent backfill.
+
+BEGIN;
+
+-- Ensure required columns exist (idempotent)
+ALTER TABLE IF EXISTS bank_accounts
+    ADD COLUMN IF NOT EXISTS gl_account_id UUID REFERENCES accounts(id);
+
+ALTER TABLE IF EXISTS bank_accounts
+    ADD COLUMN IF NOT EXISTS cash_account_id UUID REFERENCES accounts(id);
+
+ALTER TABLE IF EXISTS bank_accounts
+    ADD COLUMN IF NOT EXISTS beginning_balance DECIMAL(15,2) NOT NULL DEFAULT 0.00;
+
+ALTER TABLE IF EXISTS bank_accounts
+    ADD COLUMN IF NOT EXISTS beginning_balance_date DATE;
+
+ALTER TABLE IF EXISTS bank_accounts
+    ADD COLUMN IF NOT EXISTS connection_method VARCHAR(50) DEFAULT 'Manual';
+
+ALTER TABLE IF EXISTS bank_accounts
+    ADD COLUMN IF NOT EXISTS description TEXT;
+
+ALTER TABLE IF EXISTS bank_accounts
+    ADD COLUMN IF NOT EXISTS last_sync TIMESTAMPTZ;
+
+ALTER TABLE IF EXISTS bank_accounts
+    ADD COLUMN IF NOT EXISTS last_reconciliation_id UUID;
+
+ALTER TABLE IF EXISTS bank_accounts
+    ADD COLUMN IF NOT EXISTS reconciled_balance DECIMAL(15,2) DEFAULT 0.00;
+
+-- Backfill beginning balance from legacy balance when appropriate
+UPDATE bank_accounts
+   SET beginning_balance      = COALESCE(NULLIF(beginning_balance, 0.00), balance),
+       beginning_balance_date = COALESCE(beginning_balance_date, CURRENT_DATE)
+ WHERE (beginning_balance IS NULL OR beginning_balance = 0.00)
+   AND balance IS NOT NULL;
+
+-- Keep cash/gl mapping synchronized when one exists
+UPDATE bank_accounts
+   SET cash_account_id = gl_account_id
+ WHERE cash_account_id IS NULL
+   AND gl_account_id IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
Droid-assisted PR.\n\nSummary:\n- Add idempotent migration to introduce bank_accounts.beginning_balance and beginning_balance_date, with backfill from legacy balance.\n- Ensure columns referenced by runtime code exist: gl_account_id, cash_account_id, connection_method, description, last_sync, last_reconciliation_id, reconciled_balance.\n- Update master-schema.sql and db-init.sql to reflect these columns.\n\nValidation:\n- Environment setup: npm ci completed successfully.\n- Git: clean branch created, changes committed.\n\nNotes:\n- Legacy bank_accounts.balance retained. current_balance is computed when cash_account_id is linked to a GL cash account.\n- Migration is safe to run multiple times.\n\nHow to apply:\n- For existing DBs: run the migration SQL in database/migrations/2025-09-29-01_add-bank-accounts-beginning-balance.sql.\n- For fresh setups: run database/db-init.sql (includes idempotent ensures and defaults).