### PR TITLE
Users UI: Capitalize status label (keep lowercase class) [Droid-assisted]

### DIFF
--- a/src/js/app-ui.js
+++ b/src/js/app-ui.js
@@ -983,13 +983,17 @@ export function updateUsersTable() {
     sortedUsers.forEach(user => {
         // Handle both name formats (name or first_name + last_name)
         const displayName = user.name || `${user.first_name} ${user.last_name}`;
-        
+        // Normalize status for class; capitalize label for display
+        const statusRaw   = user.status || 'active';
+        const statusCls   = statusRaw.toLowerCase();
+        const statusLabel = statusRaw.charAt(0).toUpperCase() + statusRaw.slice(1);
+
         const row = document.createElement('tr');
         row.innerHTML = `
             <td>${displayName}</td>
             <td>${user.email}</td>
             <td>${user.role}</td>
-            <td><span class="status status-${user.status?.toLowerCase() || 'active'}">${user.status || 'Active'}</span></td>
+            <td><span class="status status-${statusCls}">${statusLabel}</span></td>
             <td>
                 <button class="action-button btn-edit-user" data-id="${user.id}">Edit</button>
             </td>


### PR DESCRIPTION
- Capitalize Users table status label while preserving lowercase CSS class for styling consistency.\n- Supersedes the remaining UI tweak from closed PR #5 (backend and modal normalization already on main).\n\nValidation:\n- npm ci successful.\n- App already running; change is client-side-only and non-breaking.\n\nPlease review and merge.