### PR TITLE
Fix: Dashboard funds refresh ensures up-to-date balances

### DIFF
--- a/src/js/app-data.js
+++ b/src/js/app-data.js
@@ -392,6 +392,10 @@ export async function loadUserData() {
  */
 export async function loadDashboardData() {
     try {
+        // Ensure fund balances reflect latest posted entries by re-fetching funds from API
+        // before rendering the dashboard. This avoids stale balances when navigating back
+        // to the Dashboard without having explicitly reloaded funds elsewhere.
+        await loadFundData();
         // Update dashboard title based on selected entity
         if (typeof updateDashboardTitle === 'function') {
             updateDashboardTitle();


### PR DESCRIPTION
This PR makes the Dashboard always fetch fresh funds before rendering so computed balances reflect the latest posted journal entries.\n\nChanges:\n- app-data.js: call `await loadFundData()` at the start of `loadDashboardData()`\n\nValidation:\n- npm ci completed (0 vulns)\n- Manual sanity: navigating to Dashboard now triggers GET /api/funds; fund balances update immediately after JEs.\n\nDroid-assisted.