### PR TITLE
JE list: derive Entity and Fund from line items (comma-separated)

### DIFF
--- a/src/js/app-ui.js
+++ b/src/js/app-ui.js
@@ -764,15 +764,19 @@ export function updateJournalEntriesTable() {
     }
     
     displayEntries.forEach(entry => {
-        const entityName = appState.entities.find(entity => entity.id === entry.entity_id)?.name || 'Unknown';
-        
+        const entityNameHdr = appState.entities.find(entity => entity.id === entry.entity_id)?.name || 'Unknown';
+        const derivedEntities = (entry.derived_entities || '').trim();
+        const derivedFunds = (entry.derived_funds || '').trim();
+        const entityDisplay = derivedEntities || entityNameHdr;
+        const fundDisplay = derivedFunds || 'N/A';
+
         const row = document.createElement('tr');
         row.innerHTML = `
             <td>${formatDate(entry.entry_date)}</td>
             <td>${entry.reference_number || 'N/A'}</td>
-            <td>${entry.description || 'N/A'}${appState.isConsolidatedView ? ` (${entityName})` : ''}</td>
-            <td>N/A</td>
-            <td>${entityName}</td>
+            <td>${entry.description || 'N/A'}${appState.isConsolidatedView ? ` (${entityNameHdr})` : ''}</td>
+            <td>${fundDisplay}</td>
+            <td>${entityDisplay}</td>
             <td>${formatCurrency(entry.total_amount)}</td>
             <td><span class="status status-${entry.status.toLowerCase()}">${entry.status}</span></td>
             <td>${entry.created_by || 'System'}</td>

--- a/src/routes/journal-entries.js
+++ b/src/routes/journal-entries.js
@@ -129,7 +129,36 @@ router.get('/', asyncHandler(async (req, res) => {
     const jeiCols = await getJeiCoreCols(pool);
     selectFields += `, (SELECT COUNT(*) FROM journal_entry_items WHERE ${jeiCols.jeRef} = je.id) as line_count`;
 
-    let query = `SELECT ${selectFields} FROM journal_entries je${joins} WHERE 1=1`;
+    // Derived lists (comma-separated) from line items
+    // Funds: support various schema variants (id, fund_number, fund_code)
+    const hasFundNumber = await hasColumn(pool, 'funds', 'fund_number');
+    const hasFundCode = await hasColumn(pool, 'funds', 'fund_code');
+    const fundMatchParts = [
+        `(jel.${jeiCols.fundRef}::text = f.id::text)`
+    ];
+    if (hasFundNumber) fundMatchParts.push(`(jel.${jeiCols.fundRef}::text = f.fund_number::text)`);
+    if (hasFundCode) fundMatchParts.push(`(jel.${jeiCols.fundRef}::text = f.fund_code::text)`);
+    const fundMatchClause = fundMatchParts.join(' OR ');
+
+    // LATERAL subqueries to aggregate derived entity and fund labels
+    const derivedJoins = `
+      LEFT JOIN LATERAL (
+        SELECT string_agg(DISTINCT COALESCE(e2.name, e2.code, a.entity_code)::text, ', ' ORDER BY COALESCE(e2.name, e2.code, a.entity_code)::text) AS derived_entities
+        FROM journal_entry_items jel
+        LEFT JOIN accounts a ON jel.${jeiCols.accRef} = a.id
+        LEFT JOIN entities e2 ON lower(e2.code) = lower(a.entity_code)
+        WHERE jel.${jeiCols.jeRef} = je.id
+      ) d_entities ON TRUE
+      LEFT JOIN LATERAL (
+        SELECT string_agg(DISTINCT COALESCE(f.fund_code, f.fund_name, f.code, f.name)::text, ', ' ORDER BY COALESCE(f.fund_code, f.fund_name, f.code, f.name)::text) AS derived_funds
+        FROM journal_entry_items jel
+        LEFT JOIN funds f ON (${fundMatchClause})
+        WHERE jel.${jeiCols.jeRef} = je.id
+      ) d_funds ON TRUE
+    `;
+    selectFields += `, COALESCE(d_entities.derived_entities, '') AS derived_entities, COALESCE(d_funds.derived_funds, '') AS derived_funds`;
+
+    let query = `SELECT ${selectFields} FROM journal_entries je${joins} ${derivedJoins} WHERE 1=1`;
     
     const params = [];
     let paramIndex = 1;


### PR DESCRIPTION
This improves the Journal Entries list to reflect the true Entities and Funds present in the entry lines.\n\nChanges\n- API: GET /api/journal-entries now returns two new fields: `derived_entities` and `derived_funds`\n  - Derived via LATERAL subqueries: Accounts→Entities; Funds via id/number/code matching\n  - Comma-separated lists; empty when not resolvable\n- UI: Journal Entries table shows these lists\n  - Fund column now uses derived_funds instead of N/A\n  - Entity column uses derived_entities (fallback to header entity)\n\nWhy\n- Header entity was always TPF for bank deposit auto-entries\n- Rows showed Fund as N/A; source lines carry actual account/fund context\n\nValidation\n- Built and installed deps with npm ci\n- Manually verified SQL compiles and UI renders using new fields\n\n[Droid-assisted]