### PR TITLE
feat(dashboard): scope metrics by entity via /api/metrics

### DIFF
--- a/src/js/app-config.js
+++ b/src/js/app-config.js
@@ -47,6 +47,7 @@ export const appState = {
     glCodes: [],            // <--- GL Codes data collection
     organizationSettings: {},
     customReportDefinitions: [],
+    dashboardMetrics: null,
     
     // Current selections and view state
     selectedEntityId: null,
@@ -141,4 +142,25 @@ export function getRelevantFunds() {
     // After funds schema refactor, funds are no longer linked by entity_id.
     // Return all funds for now; filtering (if needed) will be handled elsewhere.
     return appState.funds;
+}
+
+/**
+ * Get relevant entity codes based on selected entity and consolidated view
+ * @returns {Array<string>} entity_code values
+ */
+export function getRelevantEntityCodes() {
+    if (!appState.selectedEntityId) return [];
+
+    const selected = appState.entities.find(e => e.id === appState.selectedEntityId);
+    if (!selected) return [];
+
+    if (!appState.isConsolidatedView || !selected.is_consolidated) {
+        return [selected.code].filter(Boolean);
+    }
+
+    const childCodes = appState.entities
+        .filter(e => e.parent_entity_id === selected.id)
+        .map(e => e.code)
+        .filter(Boolean);
+    return [selected.code, ...childCodes].filter(Boolean);
 }

--- a/src/js/app-data.js
+++ b/src/js/app-data.js
@@ -412,9 +412,12 @@ export async function loadDashboardData() {
             codes.forEach(code => params.append('entity_code', code));
             const qs = params.toString() ? `?${params.toString()}` : '';
             const metrics = await fetchData(`metrics${qs}`);
-            if (metrics && typeof metrics === 'object') {
-                appState.dashboardMetrics = metrics;
-            }
+            const hasNumeric = (obj) => {
+                if (!obj || typeof obj !== 'object') return false;
+                const keys = ['assets', 'liabilities', 'net_assets', 'revenue_ytd'];
+                return keys.some(k => typeof obj[k] === 'number' && !Number.isNaN(obj[k]));
+            };
+            appState.dashboardMetrics = hasNumeric(metrics) ? metrics : null;
         } catch (e) {
             console.warn('Metrics fetch failed, falling back to client-side computation:', e);
             appState.dashboardMetrics = null;

--- a/src/routes/metrics.js
+++ b/src/routes/metrics.js
@@ -47,6 +47,7 @@ router.get('/', asyncHandler(async (req, res) => {
   // Posted tolerance
   const hasStatusCol = await hasColumn(pool, 'journal_entries', 'status');
   const hasPostedCol = await hasColumn(pool, 'journal_entries', 'posted');
+  const hasJeEntityId = await hasColumn(pool, 'journal_entries', 'entity_id');
   const postCond = (hasStatusCol && hasPostedCol)
     ? `(je.posted = TRUE OR je.status ILIKE 'post%')`
     : (hasStatusCol ? `(je.status ILIKE 'post%')` : (hasPostedCol ? `(je.posted = TRUE)` : 'TRUE'));
@@ -144,7 +145,7 @@ router.get('/', asyncHandler(async (req, res) => {
        AND ${postCond}
   `;
   const revenueParams = [yStart, yEnd];
-  if (entityIds.length) {
+  if (hasJeEntityId && entityIds.length) {
     revenueSql += ` AND je.entity_id = ANY($3)`;
     revenueParams.push(entityIds);
   }

--- a/src/routes/metrics.js
+++ b/src/routes/metrics.js
@@ -181,7 +181,8 @@ router.get('/', asyncHandler(async (req, res) => {
   const revenueParams = [yStart, yEnd];
   if (entityCodes.length) {
     if (hasAccEntityCode) {
-      revenueSql += ` AND COALESCE(a.entity_code, f.entity_code) = ANY($${revenueParams.length + 1})`;
+      // Prefer fund's entity mapping for scoping; fallback to account when fund linkage is missing
+      revenueSql += ` AND COALESCE(f.entity_code, a.entity_code) = ANY($${revenueParams.length + 1})`;
       revenueParams.push(entityCodes);
     } else {
       // Fallback: scope by funds.entity_code only


### PR DESCRIPTION
Droid-assisted\n\nSummary\n- Wire dashboard summary cards to server metrics endpoint\n- Scope by selected entity and consolidated view\n- Backend: /api/metrics now accepts entity_code(s) for funds/accounts and entity_id(s) for journal entries; frontend passes both\n- Frontend: adds appState.dashboardMetrics; updateDashboardSummaryCards prefers server values; graceful fallback to client calc\n\nNotes\n- No DB migrations required; filters are optional\n- Query example: GET /api/metrics?entity_code=TPF&entity_code=TPF-ES&entity_id=...\n\nValidation\n- Built and installed deps via npm ci\n- Local git clean; code compiles under Node 20+\n\nFollow-ups\n- Optionally add query params for date ranges on metrics\n- Update charts to use API metrics if desired