### PR TITLE
refactor(ui): remove Consolidated View checkbox; rely on dropdown 'All Entities (Consolidated)'

### DIFF
--- a/bank-deposits-batched.html
+++ b/bank-deposits-batched.html
@@ -16,10 +16,6 @@
                 <div class="db-status-container">
                     <span id="db-status-indicator" class="offline">DB Offline</span>
                 </div>
-                <div class="consolidated-view-container">
-                    <label for="consolidated-view-toggle">Consolidated View:</label>
-                    <input type="checkbox" id="consolidated-view-toggle">
-                </div>
                 <div class="entity-selector-container">
                     <label for="entity-selector" style="font-weight: 500; color: white;">Entity:</label>
                     <select id="entity-selector">

--- a/bank-deposits.html
+++ b/bank-deposits.html
@@ -17,10 +17,6 @@
                 <div class="db-status-container">
                     <span id="db-status-indicator" class="offline">DB Offline</span>
                 </div>
-                <div class="consolidated-view-container">
-                    <label for="consolidated-view-toggle">Consolidated View:</label>
-                    <input type="checkbox" id="consolidated-view-toggle">
-                </div>
                 <div class="entity-selector-container">
                     <label for="entity-selector" style="font-weight: 500; color: white;">Entity:</label>
                     <select id="entity-selector">

--- a/check-printing.html
+++ b/check-printing.html
@@ -29,10 +29,6 @@
                 <div class="db-status-container">
                     <span id="db-status-indicator" class="offline">DB Offline</span>
                 </div>
-                <div class="consolidated-view-container">
-                    <label for="consolidated-view-toggle">Consolidated View:</label>
-                    <input type="checkbox" id="consolidated-view-toggle">
-                </div>
                 <div class="entity-selector-container">
                     <label for="entity-selector" style="font-weight: 500; color: white;">Entity:</label>
                     <select id="entity-selector">

--- a/index.html
+++ b/index.html
@@ -24,10 +24,6 @@
                 <div class="db-status-container">
                     <span id="db-status-indicator" class="offline">DB Offline</span>
                 </div>
-                <div class="consolidated-view-container">
-                    <label for="consolidated-view-toggle">Consolidated View:</label>
-                    <input type="checkbox" id="consolidated-view-toggle">
-                </div>
                 <div class="entity-selector-container">
                     <label for="entity-selector" style="font-weight: 500; color: white;">Entity:</label>
                     <select id="entity-selector">

--- a/src/js/app-main.js
+++ b/src/js/app-main.js
@@ -270,32 +270,12 @@ function showPage(pageId) {
  */
 function initializeEntitySelector() {
     const entitySelector = document.getElementById('entity-selector');
-    const consolidatedViewToggle = document.getElementById('consolidated-view-toggle');
     
     if (entitySelector) {
         entitySelector.addEventListener('change', () => {
             appState.selectedEntityId = entitySelector.value;
-            
-            // Update consolidated view toggle based on selected entity
-            if (consolidatedViewToggle) {
-                const selectedEntity = appState.entities.find(entity => entity.id === appState.selectedEntityId);
-                consolidatedViewToggle.disabled = !selectedEntity || !selectedEntity.is_consolidated;
-                
-                // Reset consolidated view if entity doesn't support it
-                if (!selectedEntity || !selectedEntity.is_consolidated) {
-                    consolidatedViewToggle.checked = false;
-                    appState.isConsolidatedView = false;
-                }
-            }
-            
-            // Reload data for current page
-            refreshCurrentPageData();
-        });
-    }
-    
-    if (consolidatedViewToggle) {
-        consolidatedViewToggle.addEventListener('change', () => {
-            appState.isConsolidatedView = consolidatedViewToggle.checked;
+            const selectedEntity = appState.entities.find(entity => entity.id === appState.selectedEntityId);
+            appState.isConsolidatedView = !!(selectedEntity && selectedEntity.is_consolidated);
             
             // Reload data for current page
             refreshCurrentPageData();

--- a/src/js/app-ui.js
+++ b/src/js/app-ui.js
@@ -79,7 +79,7 @@ export function updateEntitySelector() {
     if (rootEntity) {
         const option = document.createElement('option');
         option.value = rootEntity.id;
-        option.textContent = `${rootEntity.name} (Consolidated)`;
+        option.textContent = 'All Entities (Consolidated)';
         entitySelector.appendChild(option);
     }
     
@@ -114,12 +114,9 @@ export function updateEntitySelector() {
         entitySelector.value = appState.selectedEntityId;
     }
     
-    // Set consolidated view toggle state based on selected entity
-    const consolidatedViewToggle = document.getElementById('consolidated-view-toggle');
-    if (consolidatedViewToggle && rootEntity && appState.selectedEntityId === rootEntity.id) {
-        consolidatedViewToggle.checked = true;
-        appState.isConsolidatedView = true;
-    }
+    // Derive consolidated view automatically from the selected entity
+    const selectedEntity = appState.entities.find(e => e.id === appState.selectedEntityId);
+    appState.isConsolidatedView = !!(selectedEntity && selectedEntity.is_consolidated);
 }
 
 /**


### PR DESCRIPTION
Droid-assisted

Summary
- Remove Consolidated View checkbox across app pages (index, bank-deposits, bank-deposits-batched, check-printing)
- Auto-derive consolidated mode from selected entity (is_consolidated)
- Update entity selector to include 'All Entities (Consolidated)'

Changes
- index.html, bank-deposits*.html, check-printing.html: drop checkbox markup
- src/js/app-main.js: on entity change, set appState.isConsolidatedView from selected entity
- src/js/app-ui.js: label All/Consolidated option and remove toggle refs

Validation
- npm ci successful
- Built and smoke-verified selectors locally (no checkbox element assumptions remain in modular app)

Notes
- Legacy files under src/js/ui.js and archive remain untouched (not used by modular app).