### PR TITLE
Fix: force CSS reload so main nav tabs wrap to two lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mr. MoneyBags v1.x - Fund Accounting System</title>
     <!-- Updated cache-busting query string to force latest CSS (visited-state fix) -->
-    <link rel="stylesheet" href="src/css/styles.css?v=20250721170000">
+    <link rel="stylesheet" href="src/css/styles.css?v=20251008a">
     <!-- Entity hierarchy visualization styles -->
     <link rel="stylesheet" href="src/css/entity-hierarchy.css?v=20250721150000">
     <!-- Chart.js for graphical dashboards -->


### PR DESCRIPTION
This PR bumps the styles.css cache-buster on index.html to v=20251008a so browsers fetch the updated nav styles (13px font, tighter padding, two-line wrapping via -webkit-line-clamp).\n\nWhy: Users still saw single-line tabs due to cached CSS with the old query param.\n\nChange:\n- index.html: <link> updated to styles.css?v=20251008a\n\nValidation:\n- npm ci ran successfully.\n- Visual change only; no code paths affected.\n\nDroid-assisted.