### PR TITLE
chore(vendor-payments): remove 'NACHA' from page header title

### DIFF
--- a/vendor-payments.html
+++ b/vendor-payments.html
@@ -27,7 +27,7 @@
         
         <div class="row">
             <div class="col-12">
-                <h1>NACHA Vendor Payments</h1>
+                <h1>Vendor Payments</h1>
                 <p class="lead">Manage vendors, payment batches, and generate NACHA files for ACH transfers.</p>
             </div>
         </div>


### PR DESCRIPTION
Removes the word 'NACHA' from the visible page header in Vendor Payments.\n\n- Updated vendor-payments.html: <h1> now reads 'Vendor Payments'\n- No other NACHA references changed (Settings/Files remain as-is)\n\nAll changes are non-functional UI text only. (Droid-assisted)