### PR TITLE
fix(default-reports): open reports in same tab; returning to dashboard leaves no extra tab

### DIFF
--- a/default-reports.html
+++ b/default-reports.html
@@ -108,7 +108,7 @@
 <body>
     <div class="container">
         <h1>Default Reports</h1>
-        <p>Select a report to view. Each report will open in a new window.</p>
+        <p>Select a report to view.</p>
 
         <!-- Navigation back to main dashboard -->
         <div class="navigation">
@@ -123,32 +123,32 @@
             <div class="report-card">
                 <h2>Statement of Financial Position</h2>
                 <p>Balance sheet showing assets, liabilities, and net assets as of a specific date.</p>
-                <a href="archive/reports/report-financial-position.html" target="_blank" class="report-link position">View Report</a>
+                <a href="archive/reports/report-financial-position.html" class="report-link position">View Report</a>
             </div>
             
             <div class="report-card">
                 <h2>Statement of Activities</h2>
                 <p>Income statement showing revenue, expenses, and changes in net assets.</p>
-                <a href="archive/reports/report-activities.html" target="_blank" class="report-link activities">View Report</a>
+                <a href="archive/reports/report-activities.html" class="report-link activities">View Report</a>
             </div>
             
             <div class="report-card">
                 <h2>Statement of Functional Expenses</h2>
                 <p>Expenses categorized by program services, management, and fundraising.</p>
-                <a href="archive/reports/report-functional-expenses.html" target="_blank" class="report-link expenses">View Report</a>
+                <a href="archive/reports/report-functional-expenses.html" class="report-link expenses">View Report</a>
             </div>
             
             <div class="report-card">
                 <h2>Budget vs. Actual</h2>
                 <p>Comparison of budgeted amounts to actual financial results with variances.</p>
-                <a href="archive/reports/report-budget-vs-actual.html" target="_blank" class="report-link budget">View Report</a>
+                <a href="archive/reports/report-budget-vs-actual.html" class="report-link budget">View Report</a>
             </div>
 
             <!-- New General Ledger report -->
             <div class="report-card">
                 <h2>General Ledger</h2>
                 <p>Line-by-line transactions with running balances and account summary by date range.</p>
-                <a href="gl-report.html" target="_blank" class="report-link gl">View Report</a>
+                <a href="gl-report.html" class="report-link gl">View Report</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Changes default-reports to open reports in the same tab instead of a new window. This ensures the report’s 'Back to Dashboard' navigates without leaving the reports listing tab open.\n\n- Removed target=_blank from report links\n- Updated helper text accordingly\n\nNo functional backend changes. (Droid-assisted)