### PR TITLE
fix(reports): move 'Back to Main Dashboard' to top on default reports

### DIFF
--- a/archive/reports/report-activities.html
+++ b/archive/reports/report-activities.html
@@ -99,6 +99,15 @@
 </head>
 <body>
     <div class="container">
+        <!-- Navigation button moved to top -->
+        <div class="navigation">
+            <button id="btn-back-to-main"
+                    class="button secondary"
+                    onclick="window.location.href='/index.html'">
+                &larr; Back to Main Dashboard
+            </button>
+        </div>
+
         <div class="report-header">
             <!-- Organization name will be set dynamically via JS -->
             <div id="organization-name" class="report-title">Loading...</div>
@@ -201,14 +210,7 @@
             </tbody>
         </table>
         
-        <!-- Centered navigation button -->
-        <div class="navigation">
-            <button id="btn-back-to-main"
-                    class="button secondary"
-                    onclick="window.location.href='/index.html'">
-                &larr; Back to Main Dashboard
-            </button>
-        </div>
+        
 
         <div class="actions">
             <div>

--- a/archive/reports/report-budget-vs-actual.html
+++ b/archive/reports/report-budget-vs-actual.html
@@ -96,6 +96,15 @@
 </head>
 <body>
     <div class="container">
+        <!-- Navigation button moved to top -->
+        <div class="navigation">
+            <button id="btn-back-to-main"
+                    class="button secondary"
+                    onclick="window.location.href='/index.html'">
+                &larr; Back to Main Dashboard
+            </button>
+        </div>
+
         <div class="report-header">
             <!-- Organization name will be set dynamically via JS -->
             <div id="organization-name" class="report-title">Loading...</div>
@@ -194,14 +203,7 @@
             </tbody>
         </table>
 
-        <!-- Centered navigation button -->
-        <div class="navigation">
-            <button id="btn-back-to-main"
-                    class="button secondary"
-                    onclick="window.location.href='/index.html'">
-                &larr; Back to Main Dashboard
-            </button>
-        </div>
+        
 
         <div class="actions">
             <div>

--- a/archive/reports/report-financial-position.html
+++ b/archive/reports/report-financial-position.html
@@ -90,6 +90,15 @@
 </head>
 <body>
     <div class="container">
+        <!-- Navigation button moved to top -->
+        <div class="navigation">
+            <button id="btn-back-to-main"
+                    class="button secondary"
+                    onclick="window.location.href='/index.html'">
+                &larr; Back to Main Dashboard
+            </button>
+        </div>
+
         <div class="report-header">
             <!-- Organization name will be set dynamically via JS -->
             <div id="organization-name" class="report-title">Loading...</div>
@@ -122,14 +131,7 @@
             </tbody>
         </table>
         
-        <!-- New centered navigation button -->
-        <div class="navigation">
-            <button id="btn-back-to-main"
-                    class="button secondary"
-                    onclick="window.location.href='/index.html'">
-                &larr; Back to Main Dashboard
-            </button>
-        </div>
+        
 
         <div class="actions">
             <div>

--- a/archive/reports/report-functional-expenses.html
+++ b/archive/reports/report-functional-expenses.html
@@ -96,6 +96,15 @@
 </head>
 <body>
     <div class="container">
+        <!-- Navigation button moved to top -->
+        <div class="navigation">
+            <button id="btn-back-to-main"
+                    class="button secondary"
+                    onclick="window.location.href='/index.html'">
+                &larr; Back to Main Dashboard
+            </button>
+        </div>
+
         <div class="report-header">
             <!-- Organization name will be set dynamically via JS -->
             <div id="organization-name" class="report-title">Loading...</div>
@@ -173,14 +182,7 @@
             </tbody>
         </table>
 
-        <!-- Centered navigation button -->
-        <div class="navigation">
-            <button id="btn-back-to-main"
-                    class="button secondary"
-                    onclick="window.location.href='/index.html'">
-                &larr; Back to Main Dashboard
-            </button>
-        </div>
+        
 
         <div class="actions">
             <div>


### PR DESCRIPTION
Moves the 'Back to Main Dashboard' button to the top of each default report page for better visibility and consistent UX.\n\nUpdated pages:\n- archive/reports/report-financial-position.html\n- archive/reports/report-activities.html\n- archive/reports/report-functional-expenses.html\n- archive/reports/report-budget-vs-actual.html\n\nNo functional/backend changes. (Droid-assisted)