### PR TITLE
Docs: update frontend & backend architecture diagrams to current codebase (counts, modules, endpoints) [Droid]

### DIFF
--- a/backend-architecture-diagram.html
+++ b/backend-architecture-diagram.html
@@ -635,9 +635,9 @@
                         </div>
                         <div class="comparison-details">
                             <ul>
-                                <li>21 focused modules (3,400+ total lines)</li>
+                                <li>26 route modules (~12,965 lines across routes)</li>
                                 <li>Clean separation of concerns</li>
-                                <li>Modular server orchestration (110 lines)</li>
+                                <li>Server orchestration (273 lines)</li>
                                 <li>Domain-specific API route handlers</li>
                                 <li>Shared utilities and middleware</li>
                                 <li>Improved testability and maintainability</li>
@@ -668,7 +668,7 @@
                     <div class="module-card server" data-category="server">
                         <div class="module-header">
                             <span class="module-name">server-modular.js</span>
-                            <span class="module-lines">110 lines</span>
+                            <span class="module-lines">273 lines</span>
                         </div>
                         <div class="module-description">Main Express application orchestration, API route registration, and server startup</div>
                         <div class="module-path">./server-modular.js</div>
@@ -682,7 +682,7 @@
                     <div class="module-card core" data-category="core">
                         <div class="module-header">
                             <span class="module-name">connection.js</span>
-                            <span class="module-lines">108 lines</span>
+                            <span class="module-lines">101 lines</span>
                         </div>
                         <div class="module-description">PostgreSQL database connection pool and initialization using consolidated schema</div>
                         <div class="module-path">./src/database/connection.js</div>
@@ -695,7 +695,7 @@
                     <div class="module-card utils" data-category="utils">
                         <div class="module-header">
                             <span class="module-name">helpers.js</span>
-                            <span class="module-lines">95 lines</span>
+                            <span class="module-lines">102 lines</span>
                         </div>
                         <div class="module-description">Common utility functions and helper methods for API endpoints</div>
                         <div class="module-path">./src/utils/helpers.js</div>
@@ -708,7 +708,7 @@
                     <div class="module-card utils" data-category="utils">
                         <div class="module-header">
                             <span class="module-name">error-handler.js</span>
-                            <span class="module-lines">150 lines</span>
+                            <span class="module-lines">130 lines</span>
                         </div>
                         <div class="module-description">Centralized error handling middleware for API responses</div>
                         <div class="module-path">./src/middleware/error-handler.js</div>
@@ -722,7 +722,7 @@
                     <div class="module-card routes" data-category="routes">
                         <div class="module-header">
                             <span class="module-name">entities.js</span>
-                            <span class="module-lines">227 lines</span>
+                            <span class="module-lines">254 lines</span>
                         </div>
                         <div class="module-description">Entity hierarchy management API with circular reference detection</div>
                         <div class="module-path">./src/routes/entities.js</div>
@@ -735,7 +735,7 @@
                     <div class="module-card routes" data-category="routes">
                         <div class="module-header">
                             <span class="module-name">accounts.js</span>
-                            <span class="module-lines">215 lines</span>
+                            <span class="module-lines">688 lines</span>
                         </div>
                         <div class="module-description">Chart of accounts CRUD operations API endpoints</div>
                         <div class="module-path">./src/routes/accounts.js</div>
@@ -748,7 +748,7 @@
                     <div class="module-card routes" data-category="routes">
                         <div class="module-header">
                             <span class="module-name">funds.js</span>
-                            <span class="module-lines">206 lines</span>
+                            <span class="module-lines">689 lines</span>
                         </div>
                         <div class="module-description">Fund accounting operations and management API</div>
                         <div class="module-path">./src/routes/funds.js</div>
@@ -761,7 +761,7 @@
                     <div class="module-card routes" data-category="routes">
                         <div class="module-header">
                             <span class="module-name">vendors.js</span>
-                            <span class="module-lines">133 lines</span>
+                            <span class="module-lines">506 lines</span>
                         </div>
                         <div class="module-description">Vendor management and bank account operations API</div>
                         <div class="module-path">./src/routes/vendors.js</div>
@@ -774,7 +774,7 @@
                     <div class="module-card routes" data-category="routes">
                         <div class="module-header">
                             <span class="module-name">payment-batches.js</span>
-                            <span class="module-lines">409 lines</span>
+                            <span class="module-lines">416 lines</span>
                         </div>
                         <div class="module-description">Payment batch processing and management API endpoints</div>
                         <div class="module-path">./src/routes/payment-batches.js</div>
@@ -787,7 +787,7 @@
                     <div class="module-card routes" data-category="routes">
                         <div class="module-header">
                             <span class="module-name">nacha-settings.js</span>
-                            <span class="module-lines">205 lines</span>
+                            <span class="module-lines">227 lines</span>
                         </div>
                         <div class="module-description">NACHA configuration for ACH payments API</div>
                         <div class="module-path">./src/routes/nacha-settings.js</div>
@@ -800,7 +800,7 @@
                     <div class="module-card routes" data-category="routes">
                         <div class="module-header">
                             <span class="module-name">nacha-files.js</span>
-                            <span class="module-lines">185 lines</span>
+                            <span class="module-lines">279 lines</span>
                         </div>
                         <div class="module-description">NACHA file generation and management API</div>
                         <div class="module-path">./src/routes/nacha-files.js</div>
@@ -813,7 +813,7 @@
                     <div class="module-card routes" data-category="routes">
                         <div class="module-header">
                             <span class="module-name">journal-entries.js</span>
-                            <span class="module-lines">385 lines</span>
+                            <span class="module-lines">909 lines</span>
                         </div>
                         <div class="module-description">Double-entry bookkeeping and transaction management API</div>
                         <div class="module-path">./src/routes/journal-entries.js</div>
@@ -826,7 +826,7 @@
                     <div class="module-card routes" data-category="routes">
                         <div class="module-header">
                             <span class="module-name">bank-accounts.js</span>
-                            <span class="module-lines">201 lines</span>
+                            <span class="module-lines">399 lines</span>
                         </div>
                         <div class="module-description">Banking operations and account management API</div>
                         <div class="module-path">./src/routes/bank-accounts.js</div>
@@ -839,7 +839,7 @@
                     <div class="module-card routes" data-category="routes">
                         <div class="module-header">
                             <span class="module-name">users.js</span>
-                            <span class="module-lines">130 lines</span>
+                            <span class="module-lines">259 lines</span>
                         </div>
                         <div class="module-description">User management and authentication API endpoints</div>
                         <div class="module-path">./src/routes/users.js</div>
@@ -852,7 +852,7 @@
                     <div class="module-card routes" data-category="routes">
                         <div class="module-header">
                             <span class="module-name">reports.js</span>
-                            <span class="module-lines">189 lines</span>
+                            <span class="module-lines">494 lines</span>
                         </div>
                         <div class="module-description">Custom report builder API with dynamic queries</div>
                         <div class="module-path">./src/routes/reports.js</div>
@@ -865,13 +865,105 @@
                     <div class="module-card routes" data-category="routes">
                         <div class="module-header">
                             <span class="module-name">import.js</span>
-                            <span class="module-lines">248 lines</span>
+                            <span class="module-lines">345 lines</span>
                         </div>
                         <div class="module-description">Data import functionality API endpoints</div>
                         <div class="module-path">./src/routes/import.js</div>
                         <div class="module-tags">
                             <span class="module-tag">Routes</span>
                             <span class="module-tag">Import</span>
+                        </div>
+                    </div>
+
+                    <!-- Newly added/updated modules -->
+                    <div class="module-card routes" data-category="routes">
+                        <div class="module-header">
+                            <span class="module-name">auth.js</span>
+                            <span class="module-lines">177 lines</span>
+                        </div>
+                        <div class="module-description">Authentication routes: login, logout, session verification</div>
+                        <div class="module-path">./src/routes/auth.js</div>
+                        <div class="module-tags">
+                            <span class="module-tag">Routes</span>
+                            <span class="module-tag">Auth</span>
+                        </div>
+                    </div>
+
+                    <div class="module-card routes" data-category="routes">
+                        <div class="module-header">
+                            <span class="module-name">gl-codes.js</span>
+                            <span class="module-lines">274 lines</span>
+                        </div>
+                        <div class="module-description">GL Codes reference API providing code/name mappings</div>
+                        <div class="module-path">./src/routes/gl-codes.js</div>
+                        <div class="module-tags">
+                            <span class="module-tag">Routes</span>
+                            <span class="module-tag">Core</span>
+                        </div>
+                    </div>
+
+                    <div class="module-card routes" data-category="routes">
+                        <div class="module-header">
+                            <span class="module-name">metrics.js</span>
+                            <span class="module-lines">207 lines</span>
+                        </div>
+                        <div class="module-description">Dashboard metrics API (assets, liabilities, net assets, revenue YTD) with entity scoping</div>
+                        <div class="module-path">./src/routes/metrics.js</div>
+                        <div class="module-tags">
+                            <span class="module-tag">Routes</span>
+                            <span class="module-tag">Metrics</span>
+                        </div>
+                    </div>
+
+                    <div class="module-card routes" data-category="routes">
+                        <div class="module-header">
+                            <span class="module-name">liabilities.js</span>
+                            <span class="module-lines">91 lines</span>
+                        </div>
+                        <div class="module-description">Liabilities summary API for dashboard tiles</div>
+                        <div class="module-path">./src/routes/liabilities.js</div>
+                        <div class="module-tags">
+                            <span class="module-tag">Routes</span>
+                            <span class="module-tag">Metrics</span>
+                        </div>
+                    </div>
+
+                    <div class="module-card routes" data-category="routes">
+                        <div class="module-header">
+                            <span class="module-name">check-formats.js</span>
+                            <span class="module-lines">428 lines</span>
+                        </div>
+                        <div class="module-description">CRUD for check formats; separate from check printing endpoints</div>
+                        <div class="module-path">./src/routes/check-formats.js</div>
+                        <div class="module-tags">
+                            <span class="module-tag">Routes</span>
+                            <span class="module-tag">Checks</span>
+                        </div>
+                    </div>
+
+                    <div class="module-card routes" data-category="routes">
+                        <div class="module-header">
+                            <span class="module-name">bank-reconciliation.js</span>
+                            <span class="module-lines">1563 lines</span>
+                        </div>
+                        <div class="module-description">Full bank reconciliation workflow API (statements, matching, adjustments)</div>
+                        <div class="module-path">./src/routes/bank-reconciliation.js</div>
+                        <div class="module-tags">
+                            <span class="module-tag">Routes</span>
+                            <span class="module-tag">Banking</span>
+                        </div>
+                    </div>
+
+                    <div class="module-card routes" data-category="routes">
+                        <div class="module-header">
+                            <span class="module-name">payments-import.js</span>
+                            <span class="module-lines">951 lines</span>
+                        </div>
+                        <div class="module-description">Unified vendor payments import (analyze/process/status)</div>
+                        <div class="module-path">./src/routes/payments-import.js</div>
+                        <div class="module-tags">
+                            <span class="module-tag">Routes</span>
+                            <span class="module-tag">Payments</span>
                         </div>
                     </div>
                 </div>
@@ -940,20 +1032,20 @@ module.exports = router;</code></pre>
             <div class="section-content">
                 <div class="metrics-container">
                     <div class="metric-card">
-                        <div class="metric-value">15</div>
-                        <div class="metric-label">Focused Modules</div>
+                        <div class="metric-value">26</div>
+                        <div class="metric-label">API Route Modules</div>
                     </div>
                     <div class="metric-card">
-                        <div class="metric-value">2,900+</div>
-                        <div class="metric-label">Total Lines of Code</div>
+                        <div class="metric-value">12,965+</div>
+                        <div class="metric-label">Routes LOC</div>
                     </div>
                     <div class="metric-card">
-                        <div class="metric-value">110</div>
+                        <div class="metric-value">273</div>
                         <div class="metric-label">Server Orchestration Lines</div>
                     </div>
                     <div class="metric-card">
-                        <div class="metric-value">12</div>
-                        <div class="metric-label">API Route Modules</div>
+                        <div class="metric-value">30+</div>
+                        <div class="metric-label">Backend Modules (total)</div>
                     </div>
                 </div>
                 
@@ -1144,7 +1236,7 @@ module.exports = router;</code></pre>
             <p>Mr-Moneybags-v1.x Backend Architecture</p>
             <p>Node.js/Express API server with consolidated database schema</p>
             <div class="footer-links">
-                <a href="database-er-diagram.html">Database Schema</a>
+                <a href="database-er-diagram-core.html">Database Schema</a>
                 <a href="docs/guides/Ubuntu_Deployment_Guide_v1.x.pdf">Deployment Guide</a>
                 <a href="#">Documentation</a>
             </div>
@@ -1326,9 +1418,14 @@ module.exports = ${moduleName.replace('.js', '')};`;
                 
                 if (moduleName === 'server-modular.js') {
                     const routeDeps = [
-                        'entities', 'accounts', 'funds', 'vendors', 
-                        'payment-batches', 'nacha-settings', 'nacha-files', 'journal-entries',
-                        'bank-accounts', 'users', 'reports', 'import'
+                        'auth',
+                        'entities', 'accounts', 'funds', 'gl-codes',
+                        'metrics', 'liabilities',
+                        'vendors', 'payment-batches', 'payments-import',
+                        'nacha-settings', 'nacha-files',
+                        'journal-entries', 'bank-accounts', 'bank-deposits',
+                        'check-printing', 'check-formats',
+                        'users', 'reports', 'import', 'bank-reconciliation'
                     ];
                     
                     routeDeps.forEach(dep => {

--- a/frontend-architecture-diagram.html
+++ b/frontend-architecture-diagram.html
@@ -548,7 +548,7 @@
                     <div class="module-card auth" data-category="auth">
                         <div class="module-header">
                             <span class="module-name">login.html</span>
-                            <span class="module-lines">180 lines</span>
+                            <span class="module-lines">325 lines</span>
                         </div>
                         <div class="module-description">Professional login interface with username/password authentication, remember me functionality, and session management</div>
                         <div class="module-path">./login.html</div>
@@ -562,7 +562,7 @@
                     <div class="module-card html" data-category="html">
                         <div class="module-header">
                             <span class="module-name">index.html</span>
-                            <span class="module-lines">550 lines</span>
+                            <span class="module-lines">1288 lines</span>
                         </div>
                         <div class="module-description">Main application dashboard with role-based navigation and user session display</div>
                         <div class="module-path">./index.html</div>
@@ -576,7 +576,7 @@
                     <div class="module-card banking" data-category="banking html">
                         <div class="module-header">
                             <span class="module-name">bank-reconciliation.html</span>
-                            <span class="module-lines">320 lines</span>
+                            <span class="module-lines">835 lines</span>
                         </div>
                         <div class="module-description">Bank reconciliation interface with statement upload, transaction matching, and reporting</div>
                         <div class="module-path">./bank-reconciliation.html</div>
@@ -589,7 +589,7 @@
                     <div class="module-card banking" data-category="banking html">
                         <div class="module-header">
                             <span class="module-name">bank-deposits.html</span>
-                            <span class="module-lines">270 lines</span>
+                            <span class="module-lines">697 lines</span>
                         </div>
                         <div class="module-description">Bank deposit management with deposit slip generation and multi-item deposits</div>
                         <div class="module-path">./bank-deposits.html</div>
@@ -602,7 +602,7 @@
                     <div class="module-card banking" data-category="banking html">
                         <div class="module-header">
                             <span class="module-name">check-printing.html</span>
-                            <span class="module-lines">380 lines</span>
+                            <span class="module-lines">792 lines</span>
                         </div>
                         <div class="module-description">Check printing system with format management, print queue, and check register</div>
                         <div class="module-path">./check-printing.html</div>
@@ -615,9 +615,9 @@
                     <div class="module-card banking" data-category="banking html">
                         <div class="module-header">
                             <span class="module-name">vendor-payments.html</span>
-                            <span class="module-lines">270 lines</span>
+                            <span class="module-lines">801 lines</span>
                         </div>
-                        <div class="module-description">Vendor payments management with NACHA file generation and batch processing</div>
+                        <div class="module-description">Vendor payments management with batch processing</div>
                         <div class="module-path">./vendor-payments.html</div>
                         <div class="module-tags">
                             <span class="module-tag">Banking</span>
@@ -629,7 +629,7 @@
                     <div class="module-card css" data-category="css">
                         <div class="module-header">
                             <span class="module-name">styles.css</span>
-                            <span class="module-lines">1250 lines</span>
+                            <span class="module-lines">660 lines</span>
                         </div>
                         <div class="module-description">Main application styles for all UI components and responsive design</div>
                         <div class="module-path">./src/css/styles.css</div>
@@ -643,7 +643,7 @@
                     <div class="module-card css" data-category="css banking">
                         <div class="module-header">
                             <span class="module-name">bank-reconciliation.css</span>
-                            <span class="module-lines">210 lines</span>
+                            <span class="module-lines">1198 lines</span>
                         </div>
                         <div class="module-description">Styles for reconciliation interface with drag-and-drop, split views, and status indicators</div>
                         <div class="module-path">./src/css/bank-reconciliation.css</div>
@@ -656,7 +656,7 @@
                     <div class="module-card css" data-category="css banking">
                         <div class="module-header">
                             <span class="module-name">bank-deposits.css</span>
-                            <span class="module-lines">165 lines</span>
+                            <span class="module-lines">959 lines</span>
                         </div>
                         <div class="module-description">Styles for deposit management with deposit slip styling and print-friendly layouts</div>
                         <div class="module-path">./src/css/bank-deposits.css</div>
@@ -669,7 +669,7 @@
                     <div class="module-card css" data-category="css banking">
                         <div class="module-header">
                             <span class="module-name">check-printing.css</span>
-                            <span class="module-lines">230 lines</span>
+                            <span class="module-lines">1067 lines</span>
                         </div>
                         <div class="module-description">Styles for check printing with check templates, format editor, and print-specific CSS</div>
                         <div class="module-path">./src/css/check-printing.css</div>
@@ -682,9 +682,9 @@
                     <div class="module-card css" data-category="css banking">
                         <div class="module-header">
                             <span class="module-name">vendor-payments.css</span>
-                            <span class="module-lines">78 lines</span>
+                            <span class="module-lines">127 lines</span>
                         </div>
-                        <div class="module-description">Styles for vendor payments interface and NACHA file management</div>
+                        <div class="module-description">Styles for vendor payments interface</div>
                         <div class="module-path">./src/css/vendor-payments.css</div>
                         <div class="module-tags">
                             <span class="module-tag">CSS</span>
@@ -696,7 +696,7 @@
                     <div class="module-card js" data-category="js">
                         <div class="module-header">
                             <span class="module-name">app.js</span>
-                            <span class="module-lines">680 lines</span>
+                            <span class="module-lines">94 lines</span>
                         </div>
                         <div class="module-description">Main application controller with authentication, session management, and role-based access control</div>
                         <div class="module-path">./src/js/app.js</div>
@@ -710,7 +710,7 @@
                     <div class="module-card js" data-category="js">
                         <div class="module-header">
                             <span class="module-name">ui.js</span>
-                            <span class="module-lines">320 lines</span>
+                            <span class="module-lines">795 lines</span>
                         </div>
                         <div class="module-description">UI interaction handlers and dynamic content rendering</div>
                         <div class="module-path">./src/js/ui.js</div>
@@ -723,7 +723,7 @@
                     <div class="module-card js" data-category="js">
                         <div class="module-header">
                             <span class="module-name">utils.js</span>
-                            <span class="module-lines">185 lines</span>
+                            <span class="module-lines">189 lines</span>
                         </div>
                         <div class="module-description">Utility functions for data formatting, validation, and manipulation</div>
                         <div class="module-path">./src/js/utils.js</div>
@@ -737,7 +737,7 @@
                     <div class="module-card js" data-category="js banking">
                         <div class="module-header">
                             <span class="module-name">bank-reconciliation-core.js</span>
-                            <span class="module-lines">420 lines</span>
+                            <span class="module-lines">2178 lines</span>
                         </div>
                         <div class="module-description">Bank reconciliation functionality with auto-matching algorithms and transaction management</div>
                         <div class="module-path">./src/js/bank-reconciliation-core.js</div>
@@ -750,7 +750,7 @@
                     <div class="module-card js" data-category="js banking">
                         <div class="module-header">
                             <span class="module-name">bank-deposits.js</span>
-                            <span class="module-lines">380 lines</span>
+                            <span class="module-lines">1704 lines</span>
                         </div>
                         <div class="module-description">Bank deposit management with deposit slip generation and workflow functionality</div>
                         <div class="module-path">./src/js/bank-deposits.js</div>
@@ -763,7 +763,7 @@
                     <div class="module-card js" data-category="js banking">
                         <div class="module-header">
                             <span class="module-name">check-printing-core.js</span>
-                            <span class="module-lines">480 lines</span>
+                            <span class="module-lines">824 lines</span>
                         </div>
                         <div class="module-description">Core check printing functionality with state management and API integration</div>
                         <div class="module-path">./src/js/check-printing-core.js</div>
@@ -776,7 +776,7 @@
                     <div class="module-card js" data-category="js banking">
                         <div class="module-header">
                             <span class="module-name">check-printing-forms.js</span>
-                            <span class="module-lines">320 lines</span>
+                            <span class="module-lines">606 lines</span>
                         </div>
                         <div class="module-description">Check form management with validation and amount-to-words conversion</div>
                         <div class="module-path">./src/js/check-printing-forms.js</div>
@@ -789,7 +789,7 @@
                     <div class="module-card js" data-category="js banking">
                         <div class="module-header">
                             <span class="module-name">check-printing-extras.js</span>
-                            <span class="module-lines">280 lines</span>
+                            <span class="module-lines">927 lines</span>
                         </div>
                         <div class="module-description">Print queue management, format management, and preview operations</div>
                         <div class="module-path">./src/js/check-printing-extras.js</div>
@@ -802,9 +802,9 @@
                     <div class="module-card js" data-category="js banking">
                         <div class="module-header">
                             <span class="module-name">vendor-payments.js</span>
-                            <span class="module-lines">392 lines</span>
+                            <span class="module-lines">2048 lines</span>
                         </div>
-                        <div class="module-description">Vendor payment management and NACHA file generation functionality</div>
+                        <div class="module-description">Vendor payment management and batch processing functionality</div>
                         <div class="module-path">./src/js/vendor-payments.js</div>
                         <div class="module-tags">
                             <span class="module-tag">JavaScript</span>
@@ -815,11 +815,11 @@
                     <!-- Documentation Modules -->
                     <div class="module-card doc" data-category="doc">
                         <div class="module-header">
-                            <span class="module-name">database-er-diagram.html</span>
-                            <span class="module-lines">1535 lines</span>
+                            <span class="module-name">database-er-diagram-core.html</span>
+                            <span class="module-lines">1574 lines</span>
                         </div>
                         <div class="module-description">Interactive database entity-relationship diagram with all banking tables</div>
-                        <div class="module-path">./database-er-diagram.html</div>
+                        <div class="module-path">./database-er-diagram-core.html</div>
                         <div class="module-tags">
                             <span class="module-tag">Documentation</span>
                             <span class="module-tag">Interactive</span>
@@ -829,7 +829,7 @@
                     <div class="module-card doc" data-category="doc">
                         <div class="module-header">
                             <span class="module-name">backend-architecture-diagram.html</span>
-                            <span class="module-lines">1450 lines</span>
+                            <span class="module-lines">1488 lines</span>
                         </div>
                         <div class="module-description">Interactive backend architecture visualization</div>
                         <div class="module-path">./backend-architecture-diagram.html</div>
@@ -1013,11 +1013,11 @@
             <div class="section-content">
                 <div class="metrics-container">
                     <div class="metric-card">
-                        <div class="metric-value">21+</div>
+                        <div class="metric-value">22+</div>
                         <div class="metric-label">Frontend Modules</div>
                     </div>
                     <div class="metric-card">
-                        <div class="metric-value">6,800+</div>
+                        <div class="metric-value">18,000+</div>
                         <div class="metric-label">Total Lines of Code</div>
                     </div>
                     <div class="metric-card">
@@ -1117,7 +1117,7 @@
                         
                         <!-- API Endpoints -->
                         <text x="400" y="320" text-anchor="middle" font-size="14">Key API Endpoints:</text>
-                        <text x="400" y="345" text-anchor="middle" font-size="12">/api/auth, /api/bank-reconciliation, /api/bank-deposits, /api/checks, /api/check-formats</text>
+                        <text x="400" y="345" text-anchor="middle" font-size="12">/api/auth, /api/bank-reconciliation, /api/bank-deposits, /api/checks, /api/check-formats, /api/vendor-payments/import, /api/metrics, /api/liabilities</text>
                     </svg>
                 </div>
             </div>
@@ -1129,7 +1129,7 @@
             <p>Mr-Moneybags-v1.x Frontend Architecture</p>
             <p>Modular frontend with authentication, banking modules, and role-based access control</p>
             <div class="footer-links">
-                <a href="database-er-diagram.html">Database Schema</a>
+                <a href="database-er-diagram-core.html">Database Schema</a>
                 <a href="backend-architecture-diagram.html">Backend Architecture</a>
                 <a href="docs/guides/Ubuntu_Deployment_Guide_v1.x.pdf">Deployment Guide</a>
             </div>


### PR DESCRIPTION
This PR updates the architectural documentation ONLY to reflect the current truth of the codebase and database. No application or schema logic changes.

Scope
- frontend-architecture-diagram.html
  - Update line counts for HTML/CSS/JS modules using actual wc -l
  - Remove outdated NACHA references in vendor payments
  - Update footer link to database-er-diagram-core.html
  - Update metrics (modules: 22+, LOC: 18,000+) and key API endpoints (/api/vendor-payments/import, /api/metrics, /api/liabilities)
- backend-architecture-diagram.html
  - Update dependency list (routeDeps) to include all current route modules
  - Fix footer link to database-er-diagram-core.html

Validation
- Repo synced, npm ci (162 packages, 0 vulns)
- Viewed docs locally; links and labels render correctly

Notes
- Documentation-only; safe to merge.
- Droid-assisted PR.
